### PR TITLE
pkg/operator: update cr init status

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -17,7 +17,7 @@ import (
 
 func (v *Vaults) run(ctx context.Context) {
 	source := cache.NewListWatchFromClient(
-		v.restClient,
+		v.vaultsCRCli.RESTClient(),
 		spec.VaultResourcePlural,
 		v.namespace,
 		fields.Everything())
@@ -60,7 +60,7 @@ func (v *Vaults) onAdd(obj interface{}) {
 		// TODO: retry or report failure status in CR
 		panic(err)
 	}
-	go monitorAndUpdateStaus(context.TODO(), vr)
+	go v.monitorAndUpdateStaus(context.TODO(), vr.GetName(), vr.GetNamespace())
 }
 
 // prepareVaultConfig appends etcd storage section into user provided vault config

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -11,26 +11,23 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type Vaults struct {
 	namespace string
 
 	kubecli       kubernetes.Interface
-	restClient    *rest.RESTClient
+	vaultsCRCli   client.Vaults
 	kubeExtClient apiextensionsclient.Interface
 	etcdCRCli     etcdCRClient.EtcdClusterCR
 }
 
 // New creates a vault operator.
 func New() *Vaults {
-	vc := client.MustNewInCluster()
-
 	return &Vaults{
 		namespace:     os.Getenv("MY_POD_NAMESPACE"),
 		kubecli:       k8sutil.MustNewKubeClient(),
-		restClient:    vc.RESTClient(),
+		vaultsCRCli:   client.MustNewInCluster(),
 		kubeExtClient: k8sutil.MustNewKubeExtClient(),
 		etcdCRCli:     etcdCRClient.MustNewCRInCluster(),
 	}

--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -13,40 +13,58 @@ import (
 
 // monitorAndUpdateStaus monitors the vault service and replicas statuses, and
 // updates the status resrouce in the vault CR item.
-func monitorAndUpdateStaus(ctx context.Context, v *spec.Vault) {
+func (vs *Vaults) monitorAndUpdateStaus(ctx context.Context, name, namespace string) {
 	// create a long-live client for accssing vault service.
 	cfg := vaultapi.DefaultConfig()
-	cfg.Address = k8sutil.VaultServiceAddr(v.Name, v.Namespace)
-	vsc, err := vaultapi.NewClient(cfg)
+	cfg.Address = k8sutil.VaultServiceAddr(name, namespace)
+	vapi, err := vaultapi.NewClient(cfg)
 	if err != nil {
-		logrus.Errorf("failed creating client for vault service: %s/%s", v.Name, v.Namespace)
+		logrus.Errorf("failed creating client for the vault service: %s/%s", name, namespace)
 	}
 
-	s := v.Status
+	s := spec.VaultStatus{}
 
 	for {
 		select {
 		case err := <-ctx.Done():
-			logrus.Infof("stopped monitoring vault: %s (%v)", v.Name, err)
+			logrus.Infof("stopped monitoring vault: %s (%v)", name, err)
 		case <-time.After(10 * time.Second):
 		}
-		updateVaultStatus(ctx, vsc, v, &s)
+		err := updateVaultStatus(ctx, vapi, &s)
+		if err != nil {
+			logrus.Errorf("failed getting the init status for the vault service: %s (%v)", name, err)
+			continue
+		}
 
-		// TODO: update status in the CR item.
+		err = vs.updateVaultCRStatus(ctx, name, namespace, s)
+		if err != nil {
+			logrus.Errorf("failed updating the status for the vault service: %s (%v)", name, err)
+		}
 	}
 }
 
 // updateVaultStatus updates the vault service status through the service DNS address.
-func updateVaultStatus(ctx context.Context, vc *vaultapi.Client, v *spec.Vault, s *spec.VaultStatus) {
+func updateVaultStatus(ctx context.Context, vc *vaultapi.Client, s *spec.VaultStatus) error {
 	inited, err := vc.Sys().InitStatus()
 	if err != nil {
-		logrus.Errorf("failed getting the init status for vault service: %s (%v)", v.Name, err)
-		return
+		return err
 	}
 	s.Initialized = inited
+	return nil
 }
 
 // updateVaultReplicasStatus updates the status of every vault replicas in the vault deployment.
-func updateVaultReplicasStatus(ctx context.Context, v *spec.Vault, s *spec.VaultStatus) {
+func updateVaultReplicasStatus(ctx context.Context, name, namespace string, s *spec.VaultStatus) {
 	// nothing here.
+}
+
+// updateVaultCRStatus updates the status field of the Vault CR.
+func (vs *Vaults) updateVaultCRStatus(ctx context.Context, name, namespace string, status spec.VaultStatus) error {
+	vault, err := vs.vaultsCRCli.Get(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+	vault.Status = status
+	_, err = vs.vaultsCRCli.Update(ctx, vault)
+	return err
 }


### PR DESCRIPTION
```
apiVersion: vault.coreos.com/v1alpha1
kind: Vault
metadata:
  clusterName: ""
  creationTimestamp: 2017-07-30T17:01:57Z
  generation: 0
  name: example-vault
  namespace: default
  resourceVersion: "1086415"
  selfLink: /apis/vault.coreos.com/v1alpha1/namespaces/default/vaults/example-vault
  uid: cbb97af5-7548-11e7-b190-06a6b036e842
spec:
  baseImage: ""
  configMapName: example-vault-config
  version: ""
status:
  availableNodes: null
  initialized: false
  leaderNode: ""
  sealedNodes: null
  standbyNodes: ""
```