### PR TITLE
pkg/*: update active node status

### DIFF
--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	vaultapi "github.com/hashicorp/vault/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // monitorAndUpdateStaus monitors the vault service and replicas statuses, and
@@ -36,6 +38,8 @@ func (vs *Vaults) monitorAndUpdateStaus(ctx context.Context, name, namespace str
 			continue
 		}
 
+		vs.updateVaultReplicasStatus(ctx, name, namespace, &s)
+
 		err = vs.updateVaultCRStatus(ctx, name, namespace, s)
 		if err != nil {
 			logrus.Errorf("failed updating the status for the vault service: %s (%v)", name, err)
@@ -54,8 +58,38 @@ func updateVaultStatus(ctx context.Context, vc *vaultapi.Client, s *spec.VaultSt
 }
 
 // updateVaultReplicasStatus updates the status of every vault replicas in the vault deployment.
-func updateVaultReplicasStatus(ctx context.Context, name, namespace string, s *spec.VaultStatus) {
-	// nothing here.
+func (vs *Vaults) updateVaultReplicasStatus(ctx context.Context, name, namespace string, s *spec.VaultStatus) {
+	sel := k8sutil.PodsLeablesForVault(name)
+	// TODO: handle upgrades when pods from two replicaset can co-exist :(
+	opt := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(sel).String()}
+	pods, err := vs.kubecli.CoreV1().Pods(namespace).List(opt)
+	if err != nil {
+		logrus.Errorf("failed to update vault replica status: failed listing pods for the vault service: %s/%s", name, namespace)
+		return
+	}
+
+	for _, p := range pods.Items {
+		cfg := vaultapi.DefaultConfig()
+		// TODO: change to https.
+		// TODO: use FQDN?
+		cfg.Address = "http://" + p.Status.PodIP + ":8200"
+		vapi, err := vaultapi.NewClient(cfg)
+		if err != nil {
+			logrus.Errorf("failed to update vault replica status: failed creating client for the vault pod: %s/%s", p.GetName(), namespace)
+			continue
+		}
+		hr, err := vapi.Sys().Health()
+		if err != nil {
+			logrus.Errorf("failed to update vault replica status:  failed requesting health information for the vault pod: %s/%s", p.GetName(), namespace)
+			continue
+		}
+
+		// is active node?
+		// TODO: add to vaultutil?
+		if hr.Initialized && !hr.Sealed && !hr.Standby {
+			s.ActiveNode = cfg.Address
+		}
+	}
 }
 
 // updateVaultCRStatus updates the status field of the Vault CR.

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -42,10 +42,10 @@ type VaultStatus struct {
 	// to serve requests.
 	AvailableNodes []string `json:"availableNodes"`
 
-	// Endpoint of the leader Vault node. Leader node is unsealed.
-	// Only leader node can serve requests.
-	// Vault service only points to the leader node.
-	LeaderNode string `json:"leaderNode"`
+	// Endpoint of the active Vault node. Active node is unsealed.
+	// Only active node can serve requests.
+	// Vault service only points to the active node.
+	ActiveNode string `json:"activeNode"`
 
 	// Endpoints of the standby Vault nodes. Standby nodes are unsealed.
 	// Standby nodes cannot serve requests directly. All requests will

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -82,7 +82,7 @@ func DeleteEtcdCluster(etcdCRCli etcdCRClient.EtcdClusterCR, v *spec.Vault) erro
 func DeployVault(kubecli kubernetes.Interface, v *spec.Vault) error {
 	// TODO: set owner ref.
 
-	selector := map[string]string{"app": "vault", "name": v.GetName()}
+	selector := PodsLeablesForVault(v.GetName())
 
 	podTempl := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -208,4 +208,10 @@ func etcdNameForVault(name string) string {
 // EtcdURLForVault returns the URL to talk to etcd cluster for the given vault's name
 func EtcdURLForVault(name string) string {
 	return fmt.Sprintf("http://%s-client:2379", etcdNameForVault(name))
+}
+
+// PodsLabelsForVault returns the labels for selecting the pods belongs to the given vault
+// name.
+func PodsLeablesForVault(name string) map[string]string {
+	return map[string]string{"app": "vault", "name": name}
 }


### PR DESCRIPTION
after init and unseal

```
kubectl get vaults example-vault -o yaml
apiVersion: vault.coreos.com/v1alpha1
kind: Vault
metadata:
  clusterName: ""
  creationTimestamp: 2017-07-30T19:28:57Z
  generation: 0
  name: example-vault
  namespace: default
  resourceVersion: "1114987"
  selfLink: /apis/vault.coreos.com/v1alpha1/namespaces/default/vaults/example-vault
  uid: 54aa59af-755d-11e7-b190-06a6b036e842
spec:
  baseImage: ""
  configMapName: example-vault-config
  version: ""
status:
  activeNode: http://10.2.1.29:8200
  availableNodes: null
  initialized: true
  sealedNodes: null
  standbyNodes: ""
```