### PR TITLE
pkg/operator: do not persevere sealed nodes

### DIFF
--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -45,8 +45,8 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, name, namespace 
 		return
 	}
 
+	var sealNodes []string
 	// If it can't talk to any vault pod, we are not changing the state.
-	sealNodes := s.SealedNodes
 	inited := s.Initialized
 
 	for _, p := range pods.Items {


### PR DESCRIPTION
Sealed status is a per pod and per start status.
No need to persevere it.

/cc @hongchaodeng 