### PR TITLE
*: add TLS option for vault server

### DIFF
--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -3,6 +3,9 @@ package operator
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 	"time"
 
 	"github.com/coreos-inc/vault-operator/pkg/spec"
@@ -16,27 +19,32 @@ import (
 
 // monitorAndUpdateStaus monitors the vault service and replicas statuses, and
 // updates the status resrouce in the vault CR item.
-func (vs *Vaults) monitorAndUpdateStaus(ctx context.Context, name, namespace string) {
+func (vs *Vaults) monitorAndUpdateStaus(ctx context.Context, vr *spec.Vault) {
+	tlsConfig, err := vs.readClientTLSFromSecret(vr)
+	if err != nil {
+		panic(fmt.Errorf("failed to read TLS config for vault client: %v", err))
+	}
+
 	s := spec.VaultStatus{}
 
 	for {
 		select {
 		case err := <-ctx.Done():
-			logrus.Infof("stopped monitoring vault: %s (%v)", name, err)
+			logrus.Infof("stopped monitoring vault: %s (%v)", vr.GetName(), err)
 		case <-time.After(10 * time.Second):
 		}
 
-		vs.updateLocalVaultCRStatus(ctx, name, namespace, &s)
+		vs.updateLocalVaultCRStatus(ctx, vr.GetName(), vr.GetNamespace(), &s, tlsConfig)
 
-		err := vs.updateVaultCRStatus(ctx, name, namespace, s)
+		err := vs.updateVaultCRStatus(ctx, vr.GetName(), vr.GetNamespace(), s)
 		if err != nil {
-			logrus.Errorf("failed updating the status for the vault service: %s (%v)", name, err)
+			logrus.Errorf("failed updating the status for the vault service: %s (%v)", vr.GetName(), err)
 		}
 	}
 }
 
 // updateLocalVaultCRStatus updates local vault CR status by querying each vault pod's API.
-func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, name, namespace string, s *spec.VaultStatus) {
+func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, name, namespace string, s *spec.VaultStatus, tlsConfig *vaultapi.TLSConfig) {
 	sel := k8sutil.LabelsForVault(name)
 	// TODO: handle upgrades when pods from two replicaset can co-exist :(
 	opt := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(sel).String()}
@@ -52,9 +60,9 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, name, namespace 
 
 	for _, p := range pods.Items {
 		cfg := vaultapi.DefaultConfig()
-		// TODO: change to https.
-		podURL := fmt.Sprintf("http://%s:8200", k8sutil.PodDNSName(p.Status.PodIP, namespace))
+		podURL := fmt.Sprintf("https://%s:8200", k8sutil.PodDNSName(p.Status.PodIP, namespace))
 		cfg.Address = podURL
+		cfg.ConfigureTLS(tlsConfig)
 		vapi, err := vaultapi.NewClient(cfg)
 		if err != nil {
 			logrus.Errorf("failed to update vault replica status: failed creating client for the vault pod (%s/%s): %v", namespace, p.GetName(), err)
@@ -92,4 +100,23 @@ func (vs *Vaults) updateVaultCRStatus(ctx context.Context, name, namespace strin
 	vault.Status = status
 	_, err = vs.vaultsCRCli.Update(ctx, vault)
 	return err
+}
+
+func (vs *Vaults) readClientTLSFromSecret(vr *spec.Vault) (*vaultapi.TLSConfig, error) {
+	secret, err := vs.kubecli.CoreV1().Secrets(vr.GetNamespace()).Get(vr.Spec.TLS.Static.ClientSecret, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("read client tls failed: failed to get secret (%s): %v", vr.Spec.TLS.Static.ClientSecret, err)
+	}
+
+	// Read the secret and write ca.crt to a temporary file
+	caCertData := secret.Data[spec.CATLSCertName]
+	if err := os.MkdirAll(k8sutil.VaultTLSAssetDir, 0700); err != nil {
+		return nil, fmt.Errorf("read client tls failed: failed to make dir: %v", err)
+	}
+	caCertFile := path.Join(k8sutil.VaultTLSAssetDir, spec.CATLSCertName)
+	err = ioutil.WriteFile(caCertFile, caCertData, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("read client tls failed: write ca cert file failed: %v", err)
+	}
+	return &vaultapi.TLSConfig{CACert: caCertFile}, nil
 }

--- a/pkg/util/vaultutil/vault_config.go
+++ b/pkg/util/vaultutil/vault_config.go
@@ -3,11 +3,23 @@ package vaultutil
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
 )
 
 // TODO: add TLS configs
+
+const (
+	serverTLSCertName = "server.crt"
+	serverTLSKeyName  = "server.key"
+)
+
+var vaultServerTLSFmt = `
+  tls_cert_file = "%s"
+  tls_key_file  = "%s"
+`
+
 var etcdStorageFmt = `
 storage "etcd" {
   address = "%s"
@@ -25,5 +37,17 @@ func NewConfigWithEtcd(data, etcdURL string) string {
 	storageSection := fmt.Sprintf(etcdStorageFmt, etcdURL, filepath.Join(k8sutil.VaultTLSAssetDir, "etcd-client-ca.crt"),
 		filepath.Join(k8sutil.VaultTLSAssetDir, "etcd-client.crt"), filepath.Join(k8sutil.VaultTLSAssetDir, "etcd-client.key"))
 	data = fmt.Sprintf("%s\n%s\n", data, storageSection)
+	return data
+}
+
+// NewConfigWithTLS appends the TLS fields for vault
+// to the original config.
+func NewConfigWithTLS(data string) string {
+	// TODO: Sanitize the config data by stripping the existing TLS section fields.
+	// Or don't take in the vault.hcl file
+	clientServerTLSFields := fmt.Sprintf(vaultServerTLSFmt, filepath.Join(k8sutil.VaultTLSAssetDir, serverTLSCertName),
+		filepath.Join(k8sutil.VaultTLSAssetDir, serverTLSKeyName))
+	listenerHeader := `listener "tcp" {`
+	data = strings.Replace(data, listenerHeader, listenerHeader+clientServerTLSFields, 1)
 	return data
 }


### PR DESCRIPTION
The vault-operator will mount the secret specified by `Spec.TLS.Static.ServerSecret` as a volume for the vault pod, and change the configuration data for vault to use those TLS assets in the secret.

The vault-operator will also use the CA certificate file ca.crt specified by `Spec.TLS.Static.ClientSecret` to verify the server certificate while talking to it.