### PR TITLE
*: use DNS name of vault pod

### DIFF
--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/coreos-inc/vault-operator/pkg/spec"
@@ -52,8 +53,7 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, name, namespace 
 	for _, p := range pods.Items {
 		cfg := vaultapi.DefaultConfig()
 		// TODO: change to https.
-		// TODO: use FQDN?
-		podURL := "http://" + p.Status.PodIP + ":8200"
+		podURL := fmt.Sprintf("http://%s:8200", k8sutil.PodDNSName(p.Status.PodIP, namespace))
 		cfg.Address = podURL
 		vapi, err := vaultapi.NewClient(cfg)
 		if err != nil {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -1,6 +1,9 @@
 package k8sutil
 
 import (
+	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -12,4 +15,10 @@ func CascadeDeleteBackground() *metav1.DeleteOptions {
 			return &background
 		}(),
 	}
+}
+
+// PodDNSName constructs the dns name on which a pod can be addressed
+func PodDNSName(podIP, namespace string) string {
+	podIP = strings.Replace(podIP, ".", "-", -1)
+	return fmt.Sprintf("%s.%s.pod", podIP, namespace)
 }

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -226,10 +226,9 @@ func DeployVault(kubecli kubernetes.Interface, v *spec.Vault) error {
 			}},
 		},
 	}
-
 	_, err = kubecli.CoreV1().Services(v.Namespace).Create(svc)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+		return fmt.Errorf("failed to create vault service: %v", err)
 	}
 	return nil
 }
@@ -246,7 +245,7 @@ func VaultServiceAddr(name, namespace string) string {
 	return "http://" + name + "." + namespace + ":8200"
 }
 
-// DestroVault destroys a vault service.
+// DestroyVault destroys a vault service.
 // TODO: remove this function when CRD GC is enabled.
 func DestroyVault(kubecli kubernetes.Interface, v *spec.Vault) error {
 	bg := metav1.DeletePropagationBackground


### PR DESCRIPTION
The vault-operator now uses FQDN(instead of the podIP) of the vault-pod while talking to it via the vault-client.
This is needed to move the vault-server tls PR forward.
https://github.com/coreos-inc/vault-operator/pull/51#issuecomment-320364751


/cc @xiang90 @hongchaodeng 

Edit:
Ended up using the pod dns name assigned to each pod
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods
```
When enabled, pods are assigned a DNS A record in the form of pod-ip-address.my-namespace.pod.cluster.local.
For example, a pod with IP 1.2.3.4 in the namespace default with a DNS name of cluster.local would have an entry: 1-2-3-4.default.pod.cluster.local.
```