### PR TITLE
*: auto-gen vault TLS secrets

### DIFF
--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -113,9 +113,14 @@ func (vs *Vaults) updateVaultCRStatus(ctx context.Context, name, namespace strin
 }
 
 func (vs *Vaults) readClientTLSFromSecret(vr *spec.Vault) (*vaultapi.TLSConfig, error) {
-	secret, err := vs.kubecli.CoreV1().Secrets(vr.GetNamespace()).Get(vr.Spec.TLS.Static.ClientSecret, metav1.GetOptions{})
+	secretName := k8sutil.DefaultVaultClientTLSSecretName(vr.Name)
+	if spec.IsTLSConfigured(vr.Spec.TLS) {
+		secretName = vr.Spec.TLS.Static.ClientSecret
+	}
+
+	secret, err := vs.kubecli.CoreV1().Secrets(vr.GetNamespace()).Get(secretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("read client tls failed: failed to get secret (%s): %v", vr.Spec.TLS.Static.ClientSecret, err)
+		return nil, fmt.Errorf("read client tls failed: failed to get secret (%s): %v", secretName, err)
 	}
 
 	// Read the secret and write ca.crt to a temporary file

--- a/pkg/spec/vault_tls.go
+++ b/pkg/spec/vault_tls.go
@@ -29,8 +29,8 @@ type StaticTLS struct {
 	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
-// IsSecure checks if the TLS secrets for the server and client are specified
-func IsSecureServer(tp *TLSPolicy) bool {
+// IsTLSConfigured checks if the vault TLS secrets have been specified by the user
+func IsTLSConfigured(tp *TLSPolicy) bool {
 	if tp == nil || tp.Static == nil {
 		return false
 	}

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -32,6 +32,16 @@ var (
 	evnVaultRedirectAddr = "VAULT_REDIRECT_ADDR"
 )
 
+// DefaultVaultClientTLSSecretName returns the name of the default vault client TLS secret
+func DefaultVaultClientTLSSecretName(vaultName string) string {
+	return vaultName + "-default-vault-client-tls"
+}
+
+// DefaultVaultServerTLSSecretName returns the name of the default vault server TLS secret
+func DefaultVaultServerTLSSecretName(vaultName string) string {
+	return vaultName + "-default-vault-server-tls"
+}
+
 // EtcdClientTLSSecretName returns the name of etcd client TLS secret for the given vault name
 func EtcdClientTLSSecretName(vaultName string) string {
 	return vaultName + "-etcd-client-tls"
@@ -337,10 +347,15 @@ func configEtcdBackendTLS(pt *v1.PodTemplateSpec, v *spec.Vault) {
 
 // configVaultServerTLS mounts the volume containing the vault server TLS assets for the vault pod
 func configVaultServerTLS(pt *v1.PodTemplateSpec, v *spec.Vault) {
+	secretName := DefaultVaultServerTLSSecretName(v.Name)
+	if spec.IsTLSConfigured(v.Spec.TLS) {
+		secretName = v.Spec.TLS.Static.ServerSecret
+	}
+
 	serverTLSVolume := v1.VolumeProjection{
 		Secret: &v1.SecretProjection{
 			LocalObjectReference: v1.LocalObjectReference{
-				Name: v.Spec.TLS.Static.ServerSecret,
+				Name: secretName,
 			},
 		},
 	}

--- a/pkg/util/vaultutil/vault_config.go
+++ b/pkg/util/vaultutil/vault_config.go
@@ -7,11 +7,11 @@ import (
 	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
 )
 
-// TODO: add TLS configs
-
 const (
-	serverTLSCertName = "server.crt"
-	serverTLSKeyName  = "server.key"
+	// ServerTLSCertName is the filename of the vault server cert
+	ServerTLSCertName = "server.crt"
+	// ServerTLSKeyName is the filename of the vault server key
+	ServerTLSKeyName = "server.key"
 )
 
 var listenerFmt = `
@@ -45,8 +45,8 @@ func NewConfigWithEtcd(data, etcdURL string) string {
 // NewConfigWithListener appends the Listener to Vault config data.
 func NewConfigWithListener(data string) string {
 	listenerSection := fmt.Sprintf(listenerFmt,
-		filepath.Join(k8sutil.VaultTLSAssetDir, serverTLSCertName),
-		filepath.Join(k8sutil.VaultTLSAssetDir, serverTLSKeyName))
+		filepath.Join(k8sutil.VaultTLSAssetDir, ServerTLSCertName),
+		filepath.Join(k8sutil.VaultTLSAssetDir, ServerTLSKeyName))
 	data = fmt.Sprintf("%s\n%s\n", data, listenerSection)
 	return data
 }


### PR DESCRIPTION
The vault-operator will now automatically generate the required server and client secrets for vault server TLS, if the TLS secrets are not specified via the CR spec.

Tested manually and works correctly.

The only issue is that the CR spec is not updated with the auto generated TLS secret names, since that would cause `onUpdate()->UpdateVault()` to be called, resulting in a panic since the vault deployment has not yet been created.

@hongchaodeng @xiang90 PTAL while I figure out the above issue.