### PR TITLE
pkg/operator: update Vault spec for default TLS

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -46,8 +46,6 @@ func (v *Vaults) run(ctx context.Context) {
 func (v *Vaults) onAdd(obj interface{}) {
 	vr := obj.(*spec.Vault)
 
-	vr.Spec.SetDefaults()
-
 	if !spec.IsTLSConfigured(vr.Spec.TLS) {
 		err := v.prepareDefaultVaultTLSSecrets(vr)
 		if err != nil {
@@ -56,7 +54,9 @@ func (v *Vaults) onAdd(obj interface{}) {
 		}
 	}
 
-	err := v.prepareTLSSecrets(vr)
+	vr.SetDefaults()
+
+	err := v.prepareEtcdTLSSecrets(vr)
 	if err != nil {
 		// TODO: retry or report failure status in CR
 		panic(err)
@@ -117,9 +117,9 @@ func (v *Vaults) prepareVaultConfig(vr *spec.Vault) error {
 
 func (v *Vaults) onUpdate(oldObj, newObj interface{}) {
 	nvr := newObj.(*spec.Vault)
-	nvr.Spec.SetDefaults()
+	nvr.SetDefaults()
 	ovr := oldObj.(*spec.Vault)
-	ovr.Spec.SetDefaults()
+	ovr.SetDefaults()
 
 	err := k8sutil.UpdateVault(v.kubecli, ovr, nvr)
 	if err != nil {

--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -105,6 +105,8 @@ func (vs *Vaults) updateVaultCRStatus(ctx context.Context, name, namespace strin
 	if err != nil {
 		return err
 	}
+	// Propagate default values back to API. TODO: It should be handled only once.
+	vault.SetDefaults()
 	vault.Status = status
 	_, err = vs.vaultsCRCli.Update(ctx, vault)
 	return err

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -46,7 +46,8 @@ type VaultSpec struct {
 
 // SetDefaults sets the default vaules for the vault spec.
 // TODO: remove this when CRD support defaulting directly.
-func (vs *VaultSpec) SetDefaults() {
+func (v *Vault) SetDefaults() {
+	vs := v.Spec
 	if vs.Nodes == 0 {
 		vs.Nodes = 1
 	}
@@ -55,6 +56,12 @@ func (vs *VaultSpec) SetDefaults() {
 	}
 	if len(vs.Version) == 0 {
 		vs.Version = defaultVersion
+	}
+	if vs.TLS == nil {
+		vs.TLS = &TLSPolicy{Static: &StaticTLS{
+			ServerSecret: DefaultVaultServerTLSSecretName(v.Name),
+			ClientSecret: DefaultVaultClientTLSSecretName(v.Name),
+		}}
 	}
 }
 
@@ -79,4 +86,14 @@ type VaultStatus struct {
 	// Endpoints of Sealed Vault nodes. Sealed nodes MUST be manually unsealed to
 	// become standby or leader.
 	SealedNodes []string `json:"sealedNodes"`
+}
+
+// DefaultVaultClientTLSSecretName returns the name of the default vault client TLS secret
+func DefaultVaultClientTLSSecretName(vaultName string) string {
+	return vaultName + "-default-vault-client-tls"
+}
+
+// DefaultVaultServerTLSSecretName returns the name of the default vault server TLS secret
+func DefaultVaultServerTLSSecretName(vaultName string) string {
+	return vaultName + "-default-vault-server-tls"
 }

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -36,16 +36,6 @@ var (
 	evnVaultRedirectAddr = "VAULT_REDIRECT_ADDR"
 )
 
-// DefaultVaultClientTLSSecretName returns the name of the default vault client TLS secret
-func DefaultVaultClientTLSSecretName(vaultName string) string {
-	return vaultName + "-default-vault-client-tls"
-}
-
-// DefaultVaultServerTLSSecretName returns the name of the default vault server TLS secret
-func DefaultVaultServerTLSSecretName(vaultName string) string {
-	return vaultName + "-default-vault-server-tls"
-}
-
 // EtcdClientTLSSecretName returns the name of etcd client TLS secret for the given vault name
 func EtcdClientTLSSecretName(vaultName string) string {
 	return vaultName + "-etcd-client-tls"
@@ -382,7 +372,7 @@ func vaultImage(vs spec.VaultSpec) string {
 
 // VaultTLSFromSecret reads Vault CR's TLS secret and converts it into a vault client's TLS config struct.
 func VaultTLSFromSecret(kubecli kubernetes.Interface, vr *spec.Vault) (*vaultapi.TLSConfig, error) {
-	secretName := DefaultVaultClientTLSSecretName(vr.Name)
+	secretName := spec.DefaultVaultClientTLSSecretName(vr.Name)
 	if spec.IsTLSConfigured(vr.Spec.TLS) {
 		secretName = vr.Spec.TLS.Static.ClientSecret
 	}
@@ -496,7 +486,7 @@ func configEtcdBackendTLS(pt *v1.PodTemplateSpec, v *spec.Vault) {
 
 // configVaultServerTLS mounts the volume containing the vault server TLS assets for the vault pod
 func configVaultServerTLS(pt *v1.PodTemplateSpec, v *spec.Vault) {
-	secretName := DefaultVaultServerTLSSecretName(v.Name)
+	secretName := spec.DefaultVaultServerTLSSecretName(v.Name)
 	if spec.IsTLSConfigured(v.Spec.TLS) {
 		secretName = v.Spec.TLS.Static.ServerSecret
 	}


### PR DESCRIPTION
If using default TLS, we need to update the spec TLS field as well. Otherwise on restart this state won’t be known.