### PR TITLE
types: fix SetDefaults

### DIFF
--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -47,7 +47,7 @@ type VaultSpec struct {
 // SetDefaults sets the default vaules for the vault spec.
 // TODO: remove this when CRD support defaulting directly.
 func (v *Vault) SetDefaults() {
-	vs := v.Spec
+	vs := &v.Spec
 	if vs.Nodes == 0 {
 		vs.Nodes = 1
 	}


### PR DESCRIPTION
`SetDefaults()` was not really updating the `Spec` field of the Vault struct but rather making those changes for the local variable `vs`. As a consequence, none of the defaults were being saved locally or being propagated back to the API server.
Since the BaseImage was not set as default this would cause an `InvalidImageName` error when trying to pull the vault pod's image.

Testing out this change right now.