### PR TITLE
vaultutil: add disable_clustering=true

### DIFF
--- a/pkg/util/vaultutil/vault_config.go
+++ b/pkg/util/vaultutil/vault_config.go
@@ -29,6 +29,7 @@ storage "etcd" {
   address = "%s"
   etcd_api = "v3"
   ha_enabled = "true"
+  disable_clustering = "true"
   tls_ca_file = "%s"
   tls_cert_file = "%s"
   tls_key_file = "%s"


### PR DESCRIPTION
Otherwise it will keep printing the error:

```
grpc: addrConn.resetTransport failed to create client transport:
connection error: desc = "transport: Error while dialing dial tcp
10.3.141.62:8201: getsockopt: connection timed out"; Reconnecting to
{example-vault.e2e-local:8201 <nil>}
```