### PR TITLE
e2e: add portforwarding util to init and unseal vault

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0130087c7f5a37a4ef361280f7f6467e984d3fa93523740910477cfbeab6db8a
-updated: 2017-09-01T09:18:31.341635498-07:00
+updated: 2017-09-01T15:39:15.244458915-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -50,6 +50,10 @@ imports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/docker/spdystream
+  version: 449fdfce4d962303d702fec724ef0ad181c92528
+  subpackages:
+  - spdy
 - name: github.com/emicklei/go-restful
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
@@ -319,6 +323,8 @@ imports:
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
+  - pkg/util/httpstream
+  - pkg/util/httpstream/spdy
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/mergepatch
@@ -333,6 +339,7 @@ imports:
   - pkg/version
   - pkg/watch
   - third_party/forked/golang/json
+  - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: 1850dd66e4213a26bd70d0b85fee4176d324b845
@@ -373,7 +380,9 @@ imports:
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
   - tools/metrics
+  - tools/portforward
   - transport
+  - transport/spdy
   - util/cert
   - util/flowcontrol
   - util/homedir

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1,10 +1,16 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
+	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
+	"github.com/coreos-inc/vault-operator/pkg/util/vaultutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
+	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil/portforwarder"
 	"github.com/coreos-inc/vault-operator/test/e2e/framework"
+
+	vaultapi "github.com/hashicorp/vault/api"
 )
 
 func TestCreateCluster(t *testing.T) {
@@ -25,5 +31,48 @@ func TestCreateCluster(t *testing.T) {
 		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
 	}
 
-	// TODO: Init and unseal pod, then read/write to vault service
+	vault, err := f.VaultsCRClient.Get(context.TODO(), testVault.Namespace, testVault.Name)
+	if err != nil {
+		t.Fatalf("failed to get CR: %v", err)
+	}
+
+	pf, err := portforwarder.New(f.KubeClient, f.Config)
+	if err != nil {
+		t.Fatalf("failed to create a portforwarder: %v", err)
+	}
+
+	// TODO: Run e2e tests in a container to avoid port conflicts between concurrent test runs
+	ports := []string{"8200:8200"}
+	podName := vault.Status.AvailableNodes[0]
+	if err = pf.StartForwarding(podName, f.Namespace, ports); err != nil {
+		t.Fatalf("failed to forward ports to pod(%v): %v", podName, err)
+	}
+
+	defer func() {
+		if err = pf.StopForwarding(podName, f.Namespace); err != nil {
+			t.Errorf("failed to stop forwarding ports to pod(%v): %v", podName, err)
+		}
+	}()
+
+	tlsConfig, err := k8sutil.VaultTLSFromSecret(f.KubeClient, vault)
+	if err != nil {
+		t.Fatalf("failed to read TLS config for vault client: %v", err)
+	}
+
+	vapi, err := vaultutil.NewClient("localhost", tlsConfig)
+	if err != nil {
+		t.Fatalf("failed creating client for the vault pod (%s/%s): %v", f.Namespace, podName, err)
+	}
+
+	initOpts := &vaultapi.InitRequest{
+		SecretShares:    1,
+		SecretThreshold: 1,
+	}
+
+	_, err = vapi.Sys().Init(initOpts)
+	if err != nil {
+		t.Fatalf("failed to initialize vault: %v", err)
+	}
+
+	// TODO: Wait until node shows up as sealed, then unseal it.
 }

--- a/test/e2e/e2eutil/portforwarder/portforwarder.go
+++ b/test/e2e/e2eutil/portforwarder/portforwarder.go
@@ -1,0 +1,90 @@
+package portforwarder
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+type PortForwarder interface {
+	// StartForwarding starts the client-go portforwarder to listen and forward ports to the specified pod
+	// Each port string maps a local port to the target pod's port and is of the format: "<local-port>:<pod-port>"
+	StartForwarding(podName, namespace string, ports []string) error
+	// StopForwarding stops the client-go portforwarder from forwarding ports to the specified pod
+	StopForwarding(podName, namespace string) error
+}
+
+type portForwarder struct {
+	activePods map[string]chan struct{}
+	kubeClient kubernetes.Interface
+	transport  http.RoundTripper
+	upgrader   spdy.Upgrader
+}
+
+// New returns a PortForwarder that uses client-go's implementation of the httpstream.Dialer interface
+// See https://github.com/kubernetes/client-go/blob/master/transport/spdy/spdy.go
+func New(kubeClient kubernetes.Interface, config *restclient.Config) (PortForwarder, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get roundtripper: %v", err)
+	}
+	return &portForwarder{
+		activePods: map[string]chan struct{}{},
+		kubeClient: kubeClient,
+		transport:  transport,
+		upgrader:   upgrader,
+	}, nil
+}
+
+func (pf *portForwarder) StartForwarding(podName, namespace string, ports []string) error {
+	_, ok := pf.activePods[getNamespacedName(podName, namespace)]
+	if ok {
+		return fmt.Errorf("Already portforwarding to the pod (%v). Stop that first", getNamespacedName(podName, namespace))
+	}
+
+	url := pf.kubeClient.CoreV1().RESTClient().Post().Resource("pods").Namespace(namespace).Name(podName).SubResource("portforward").URL()
+
+	dialer := spdy.NewDialer(pf.upgrader, &http.Client{Transport: pf.transport}, "POST", url)
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	errChan := make(chan error)
+
+	k8sPF, err := portforward.New(dialer, ports, stopChan, readyChan, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a : %v", err)
+	}
+
+	go func() {
+		errChan <- k8sPF.ForwardPorts()
+	}()
+
+	select {
+	case err = <-errChan:
+		return fmt.Errorf("failed to forward ports: %v", err)
+	case <-readyChan:
+	}
+
+	pf.activePods[getNamespacedName(podName, namespace)] = stopChan
+	return nil
+}
+
+func (pf *portForwarder) StopForwarding(podName, namespace string) error {
+	stopChan, ok := pf.activePods[getNamespacedName(podName, namespace)]
+	if !ok {
+		return fmt.Errorf("No ports being forwarded to the pod (%v)", getNamespacedName(podName, namespace))
+	}
+
+	// Stop the client-go port forwarder for this pod
+	close(stopChan)
+	delete(pf.activePods, getNamespacedName(podName, namespace))
+	return nil
+}
+
+func getNamespacedName(name, namespace string) string {
+	return path.Join(namespace, name)
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -29,6 +30,8 @@ var (
 // Framework struct contains the various clients and other information needed to run the e2e tests
 type Framework struct {
 	KubeClient     kubernetes.Interface
+	Config         *restclient.Config
+	RESTClient     *restclient.RESTClient
 	VaultsCRClient client.Vaults
 	Namespace      string
 	vopImage       string
@@ -58,6 +61,7 @@ func Setup() error {
 
 	Global = &Framework{
 		KubeClient:     kubeClient,
+		Config:         config,
 		VaultsCRClient: vaultsCRClient,
 		Namespace:      *ns,
 		vopImage:       *vopImage,


### PR DESCRIPTION
Added a portforwarder util that uses the client-go portforwarder tool to forward vault client request to pods in the k8s cluster. This will be used in the tests to init and unseal the vault nodes.