### PR TITLE
e2e: extend TestHAClusterCreate to unseal nodes

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1,11 +1,10 @@
 package e2e
 
 import (
-	"context"
+	"fmt"
 	"testing"
 
 	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
-	"github.com/coreos-inc/vault-operator/pkg/util/vaultutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil/portforwarder"
 	"github.com/coreos-inc/vault-operator/test/e2e/framework"
@@ -13,27 +12,21 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
-func TestCreateCluster(t *testing.T) {
+func TestCreateHAVault(t *testing.T) {
 	f := framework.Global
-	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 1))
+	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 2))
 	if err != nil {
 		t.Fatalf("failed to create vault cluster: %v", err)
 	}
-
 	defer func() {
 		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, testVault); err != nil {
 			t.Fatalf("failed to delete vault cluster: %v", err)
 		}
 	}()
 
-	err = e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	vault, err := e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
 	if err != nil {
 		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
-	}
-
-	vault, err := f.VaultsCRClient.Get(context.TODO(), testVault.Namespace, testVault.Name)
-	if err != nil {
-		t.Fatalf("failed to get CR: %v", err)
 	}
 
 	pf, err := portforwarder.New(f.KubeClient, f.Config)
@@ -41,38 +34,87 @@ func TestCreateCluster(t *testing.T) {
 		t.Fatalf("failed to create a portforwarder: %v", err)
 	}
 
-	// TODO: Run e2e tests in a container to avoid port conflicts between concurrent test runs
-	ports := []string{"8200:8200"}
-	podName := vault.Status.AvailableNodes[0]
-	if err = pf.StartForwarding(podName, f.Namespace, ports); err != nil {
-		t.Fatalf("failed to forward ports to pod(%v): %v", podName, err)
-	}
-
-	defer func() {
-		if err = pf.StopForwarding(podName, f.Namespace); err != nil {
-			t.Errorf("failed to stop forwarding ports to pod(%v): %v", podName, err)
-		}
-	}()
-
 	tlsConfig, err := k8sutil.VaultTLSFromSecret(f.KubeClient, vault)
 	if err != nil {
 		t.Fatalf("failed to read TLS config for vault client: %v", err)
 	}
 
-	vapi, err := vaultutil.NewClient("localhost", tlsConfig)
-	if err != nil {
-		t.Fatalf("failed creating client for the vault pod (%s/%s): %v", f.Namespace, podName, err)
+	// TODO: Run e2e tests in a container to avoid port conflicts between concurrent test runs
+	// Portforward to all available vault nodes, and create vault clients for each pod
+	vClients := map[string]*vaultapi.Client{}
+	if err = portForwardVaultClients(f.Namespace, vClients, tlsConfig, pf, vault.Status.AvailableNodes...); err != nil {
+		t.Fatalf("failed to portforward and create vault client: %v", err)
 	}
+	defer func() {
+		pf.StopForwardingAll()
+	}()
 
-	initOpts := &vaultapi.InitRequest{
-		SecretShares:    1,
-		SecretThreshold: 1,
+	// Init vault and wait for sealed nodes
+	podName := vault.Status.AvailableNodes[0]
+	vClient, ok := vClients[podName]
+	if !ok {
+		t.Fatalf("failed to find vault client for pod (%v)", podName)
 	}
-
-	_, err = vapi.Sys().Init(initOpts)
+	initResp, err := vClient.Sys().Init(e2eutil.SingleKeyInitOptions())
 	if err != nil {
 		t.Fatalf("failed to initialize vault: %v", err)
 	}
+	vault, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
+	}
 
-	// TODO: Wait until node shows up as sealed, then unseal it.
+	// Unseal the 1st vault node and wait for it to become active
+	resp, err := vClient.Sys().Unseal(initResp.Keys[0])
+	if err != nil {
+		t.Fatalf("failed to unseal vault: %v", err)
+	}
+	if resp.Sealed {
+		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
+	}
+	vault, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, testVault)
+	if err != nil {
+		t.Fatalf("failed to wait for any node to become active: %v", err)
+	}
+
+	// Unseal the 2nd vault node(the remaining sealed node) and wait for it to become standby
+	podName = vault.Status.SealedNodes[0]
+	vClient, ok = vClients[podName]
+	if !ok {
+		t.Fatalf("failed to find vault client for pod (%v)", podName)
+	}
+	resp, err = vClient.Sys().Unseal(initResp.Keys[0])
+	if err != nil {
+		t.Fatalf("failed to unseal vault: %v", err)
+	}
+	if resp.Sealed {
+		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
+	}
+	vault, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become standby: %v", err)
+	}
+
+	// TODO: read write to vault cluster
+
+}
+
+// portForwardVaultClients creates a port forwarding session and a vault client for each vault pod.
+// The portforwarding is done on localhost X:8200 where X is some ephemeral port allocated for that pod's portforwarding session.
+// The vault clients are tracked via the vClients map passsed in.
+func portForwardVaultClients(namespace string, vClients map[string]*vaultapi.Client, tlsConfig *vaultapi.TLSConfig, pf portforwarder.PortForwarder, vaultPods ...string) error {
+	for _, podName := range vaultPods {
+		port := e2eutil.NextPortNumber()
+		// TODO: Retry with another port if it fails?
+		if err := pf.StartForwarding(podName, namespace, e2eutil.GetPortMapping(port)); err != nil {
+			return fmt.Errorf("failed to forward port(%v) to pod(%v): %v", podName, port, err)
+		}
+
+		vClient, err := e2eutil.NewVaultClient("localhost", port, tlsConfig)
+		if err != nil {
+			return fmt.Errorf("failed creating vault client for (localhost:%v): %v", port, err)
+		}
+		vClients[podName] = vClient
+	}
+	return nil
 }

--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -2,9 +2,38 @@ package e2eutil
 
 import (
 	"fmt"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+const (
+	// Ephemeral port ranges
+	ephemeralPortLowerBound = 50000
+	ephemeralPortUpperBound = 60000
+	targetVaultPort         = "8200"
+)
+
+var (
+	// Atomic counter used to assign increasing port numbers
+	portCounter int64
+)
+
+func init() {
+	portCounter = ephemeralPortLowerBound
+}
+
+// NextPortNumber returns the next port number in an atomically increasing sequence in the ephemeral port range
+func NextPortNumber() string {
+	// TODO: Watch out for upper limit
+	return strconv.FormatInt(atomic.AddInt64(&portCounter, 1), 10)
+}
+
+// GetPortMapping returns the []string{local:target} port mapping required for portforwarding
+func GetPortMapping(localPort string) []string {
+	return []string{localPort + ":" + targetVaultPort}
+}
 
 // PodLabelForOperator returns a label of the form name=<name>
 func PodLabelForOperator(name string) map[string]string {

--- a/test/e2e/e2eutil/vault_util.go
+++ b/test/e2e/e2eutil/vault_util.go
@@ -1,0 +1,24 @@
+package e2eutil
+
+import (
+	"fmt"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// SingleKeyInitOptions returns the init options that generate a single secret to unseal vault
+func SingleKeyInitOptions() *vaultapi.InitRequest {
+	return &vaultapi.InitRequest{
+		SecretShares:    1,
+		SecretThreshold: 1,
+	}
+}
+
+// NewVaultClient returns a vault client configured to make requests to the specified hostname and port
+func NewVaultClient(hostname string, port string, tlsConfig *vaultapi.TLSConfig) (*vaultapi.Client, error) {
+	cfg := vaultapi.DefaultConfig()
+	url := fmt.Sprintf("https://%s:%s", hostname, port)
+	cfg.Address = url
+	cfg.ConfigureTLS(tlsConfig)
+	return vaultapi.NewClient(cfg)
+}

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -19,6 +19,9 @@ import (
 // Retry interval used for all retries in wait related functions
 var retryInterval = 10 * time.Second
 
+// checkConditionFunc is used to check if a condition for the vault CR is true
+type checkConditionFunc func(*spec.Vault) bool
+
 // WaitUntilOperatorReady will wait until the first pod with the label name=<name> is ready.
 func WaitUntilOperatorReady(kubecli kubernetes.Interface, namespace, name string) error {
 	var podName string
@@ -44,20 +47,67 @@ func WaitUntilOperatorReady(kubecli kubernetes.Interface, namespace, name string
 	return nil
 }
 
-// WaitAvailableVaultsUp waits until the desired number of vault nodes are shown as available in the CR status
-func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) error {
-	err := retryutil.Retry(retryInterval, 6, func() (bool, error) {
-		vault, err := vaultsCRClient.Get(context.TODO(), cl.Namespace, cl.Name)
+// WaitUntilVaultConditionTrue retries until the specified condition check becomes true for the vault CR
+func WaitUntilVaultConditionTrue(t *testing.T, vaultsCRClient client.Vaults, retries int, cl *spec.Vault, checkCondition checkConditionFunc) (*spec.Vault, error) {
+	var vault *spec.Vault
+	var err error
+	err = retryutil.Retry(retryInterval, 6, func() (bool, error) {
+		vault, err = vaultsCRClient.Get(context.TODO(), cl.Namespace, cl.Name)
 		if err != nil {
 			return false, fmt.Errorf("failed to get CR: %v", err)
 		}
-
-		LogfWithTimestamp(t, "available nodes: (%v)", vault.Status.AvailableNodes)
-
-		return len(vault.Status.AvailableNodes) == size, nil
+		return checkCondition(vault), nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to wait for available size to become (%v): %v", size, err)
+		return nil, err
 	}
-	return nil
+	return vault, nil
+}
+
+// WaitAvailableVaultsUp retries until the desired number of vault nodes are shown as available in the CR status
+func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) (*spec.Vault, error) {
+	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *spec.Vault) bool {
+		LogfWithTimestamp(t, "available nodes: (%v)", v.Status.AvailableNodes)
+		return len(v.Status.AvailableNodes) == size
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for available size to become (%v): %v", size, err)
+	}
+	return vault, nil
+}
+
+// WaitSealedVaultsUp retries until the desired number of vault nodes are shown as sealed in the CR status
+func WaitSealedVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) (*spec.Vault, error) {
+	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *spec.Vault) bool {
+		LogfWithTimestamp(t, "sealed nodes: (%v)", v.Status.SealedNodes)
+		return len(v.Status.SealedNodes) == size
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for sealed size to become (%v): %v", size, err)
+	}
+	return vault, nil
+}
+
+// WaitStandbyVaultsUp retries until the desired number of vault nodes are shown as standby in the CR status
+func WaitStandbyVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) (*spec.Vault, error) {
+	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *spec.Vault) bool {
+		LogfWithTimestamp(t, "standby nodes: (%v)", v.Status.StandbyNodes)
+		return len(v.Status.StandbyNodes) == size
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for standby size to become (%v): %v", size, err)
+	}
+	return vault, nil
+}
+
+// WaitActiveVaultsUp retries until there is 1 active node in the CR status
+func WaitActiveVaultsUp(t *testing.T, vaultsCRClient client.Vaults, retries int, cl *spec.Vault) (*spec.Vault, error) {
+	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *spec.Vault) bool {
+		LogfWithTimestamp(t, "active node: (%v)", v.Status.ActiveNode)
+		return len(v.Status.ActiveNode) != 0
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for any node to become active: %v", err)
+	}
+	return vault, nil
 }


### PR DESCRIPTION
Modified the test to create an HA cluster, unseal the nodes and check for active and standby nodes.

The e2e tests should now be able to portforward to multiple vault nodes and make requests to all of them without port conflicts(within the same e2e framework) by using an atomic counter to get increasing ephemeral port numbers.