### PR TITLE
e2e: change TestClusterCreate to TestHAVaultCreate

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
 	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
@@ -13,27 +12,21 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
-func TestCreateCluster(t *testing.T) {
+func TestCreateHAVault(t *testing.T) {
 	f := framework.Global
-	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 1))
+	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 2))
 	if err != nil {
 		t.Fatalf("failed to create vault cluster: %v", err)
 	}
-
 	defer func() {
 		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, testVault); err != nil {
 			t.Fatalf("failed to delete vault cluster: %v", err)
 		}
 	}()
 
-	err = e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	vault, err := e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
 	if err != nil {
 		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
-	}
-
-	vault, err := f.VaultsCRClient.Get(context.TODO(), testVault.Namespace, testVault.Name)
-	if err != nil {
-		t.Fatalf("failed to get CR: %v", err)
 	}
 
 	pf, err := portforwarder.New(f.KubeClient, f.Config)

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -45,9 +45,11 @@ func WaitUntilOperatorReady(kubecli kubernetes.Interface, namespace, name string
 }
 
 // WaitAvailableVaultsUp waits until the desired number of vault nodes are shown as available in the CR status
-func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) error {
-	err := retryutil.Retry(retryInterval, 6, func() (bool, error) {
-		vault, err := vaultsCRClient.Get(context.TODO(), cl.Namespace, cl.Name)
+func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *spec.Vault) (*spec.Vault, error) {
+	var vault *spec.Vault
+	var err error
+	err = retryutil.Retry(retryInterval, 6, func() (bool, error) {
+		vault, err = vaultsCRClient.Get(context.TODO(), cl.Namespace, cl.Name)
 		if err != nil {
 			return false, fmt.Errorf("failed to get CR: %v", err)
 		}
@@ -57,7 +59,7 @@ func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, ret
 		return len(vault.Status.AvailableNodes) == size, nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to wait for available size to become (%v): %v", size, err)
+		return nil, fmt.Errorf("failed to wait for available size to become (%v): %v", size, err)
 	}
-	return nil
+	return vault, nil
 }


### PR DESCRIPTION
Smaller changes from #122 

`TestCreateCluster` changed to `TestHAVaultCreate` which now creates a 2 node vault cluster.

Additionally, remove the unnecessary GET of the vault CR, and instead use the already fetched CR from `WaitAvailableVaultsUp`.

/cc @hongchaodeng 