### PR TITLE
portforwarder: remove StopForwarding

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -41,12 +41,6 @@ func TestCreateHAVault(t *testing.T) {
 		t.Fatalf("failed to forward ports to pod(%v): %v", podName, err)
 	}
 
-	defer func() {
-		if err = pf.StopForwarding(podName, f.Namespace); err != nil {
-			t.Errorf("failed to stop forwarding ports to pod(%v): %v", podName, err)
-		}
-	}()
-
 	tlsConfig, err := k8sutil.VaultTLSFromSecret(f.KubeClient, vault)
 	if err != nil {
 		t.Fatalf("failed to read TLS config for vault client: %v", err)


### PR DESCRIPTION
Since we plan to use atomically increasing (or unique) port numbers for each new portforwading session, there is no need to track all the sessions and close them in order to reuse ports.

All the portforwarding sessions(go-routines) should just be cleaned up as the e2e tests finish.