### PR TITLE
e2e: add wait until sealed util

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -61,5 +61,10 @@ func TestCreateHAVault(t *testing.T) {
 		t.Fatalf("failed to initialize vault: %v", err)
 	}
 
-	// TODO: Wait until node shows up as sealed, then unseal it.
+	vault, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
+	}
+
+	// TODO: Unseal both vault nodes and wait for 1 active and 1 standby node
 }


### PR DESCRIPTION
Abstracted the wait-until-x  behavior into `WaitUntilVaultConditionTrue()`. Added util for waiting until the desired number of sealed vault nodes appear in the CR status.

/cc @hongchaodeng 