### PR TITLE
*: document labels, add labels to etcd CR and vault configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An operator to create and manage Vault instances for Kubernetes clusters on Tectonic. Vault instances created by the Vault operator are highly available and support automatic failover and upgrade.
 
+For an overview of the resources created by the vault operator see the [resource labels and ownership](doc/user/resource_labels_and_ownership.md) doc.
+
 An example namespace, `vault-services`, is used in this document.
 
 ## Prerequisites

--- a/doc/user/resource_labels_and_ownership.md
+++ b/doc/user/resource_labels_and_ownership.md
@@ -1,0 +1,14 @@
+## Resource Labels
+Currently the vault-operator creates the following Kubernetes resources to setup a vault cluster:
+- A Custom Resource for the etcd cluster storage backend
+- A Deployment for vault instances
+- A Service to serve vault client requests
+- TLS Secrets for for the etcd-cluster and vault
+- A Configmap to store the vault configuration
+
+All of the above resources created for a vault cluster have the following labels:
+
+- `app=vault`
+- `vault_cluster=<cluster-name>`
+
+where `<cluster-name>` is the name of the vault cluster to which that resource belongs.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -204,7 +204,8 @@ func (v *Vaults) prepareVaultConfig(vr *spec.Vault) error {
 
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: k8sutil.ConfigMapNameForVault(vr),
+			Name:   k8sutil.ConfigMapNameForVault(vr),
+			Labels: k8sutil.LabelsForVault(vr.Name),
 		},
 		Data: map[string]string{
 			filepath.Base(k8sutil.VaultConfigPath): cfgData,

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -58,6 +58,7 @@ func DeployEtcdCluster(etcdCRCli etcdCRClient.EtcdClusterCR, v *spec.Vault) erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EtcdNameForVault(v.Name),
 			Namespace: v.Namespace,
+			Labels:    LabelsForVault(v.Name),
 		},
 		Spec: etcdCRAPI.ClusterSpec{
 			Size: size,
@@ -352,7 +353,7 @@ func EtcdURLForVault(name string) string {
 // LabelsForVault returns the labels for selecting the resources
 // belonging to the given vault name.
 func LabelsForVault(name string) map[string]string {
-	return map[string]string{"app": "vault", "name": name}
+	return map[string]string{"app": "vault", "vault_cluster": name}
 }
 
 // configEtcdBackendTLS configures the volume and mounts in vault pod to


### PR DESCRIPTION
Changed the label `name=<cluster-name>` to `vault_cluster=<cluster-name>` to make the association of the created resources with the vault CR more clear.

Added missing label for configmap. Also since the `EtcdCluster` CR is created by the vault-operator that should also have the same labels as other created resources. Anything created further down under the `EtcdCluster` CR will not have the vault specific labels.