### PR TITLE
example: use latest image for operator

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: vault-operator
-        image: quay.io/coreos/vault-operator:0.1.0
+        image: quay.io/coreos/vault-operator:latest
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
[skip ci]
So that the README example works correctly after the changes from `0.1.0`.