### PR TITLE
e2e: add upgrade test

### DIFF
--- a/test/e2e/e2eutil/cluster_util.go
+++ b/test/e2e/e2eutil/cluster_util.go
@@ -34,6 +34,21 @@ func ResizeCluster(t *testing.T, crClient client.Vaults, cl *api.VaultService, s
 	return vault, nil
 }
 
+// UpdateVersion updates the Version field of the vault CR
+func UpdateVersion(t *testing.T, crClient client.Vaults, cl *api.VaultService, version string) (*api.VaultService, error) {
+	vault, err := crClient.Get(context.TODO(), cl.Namespace, cl.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CR: %v", err)
+	}
+	vault.Spec.Version = version
+	vault, err = crClient.Update(context.TODO(), vault)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update CR: %v", err)
+	}
+	LogfWithTimestamp(t, "updated vault cluster(%v) to version(%v)", vault.Name, version)
+	return vault, nil
+}
+
 // DeleteCluster deletes the vault CR specified by cluster spec
 func DeleteCluster(t *testing.T, crClient client.Vaults, cl *api.VaultService) error {
 	t.Logf("deleting vault cluster: %v", cl.Name)

--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -33,3 +33,12 @@ func PodLabelForOperator(name string) map[string]string {
 func LogfWithTimestamp(t *testing.T, format string, args ...interface{}) {
 	t.Log(time.Now(), fmt.Sprintf(format, args...))
 }
+
+// GetConnOrFail returns the portforward connection for the pod if it exists in the map of connections
+func GetConnOrFail(t *testing.T, podName string, conns map[string]*Connection) *Connection {
+	conn, ok := conns[podName]
+	if !ok {
+		t.Fatalf("failed to find vault client for pod (%v)", podName)
+	}
+	return conn
+}

--- a/test/e2e/e2eutil/vault_util.go
+++ b/test/e2e/e2eutil/vault_util.go
@@ -1,0 +1,57 @@
+package e2eutil
+
+import (
+	"fmt"
+	"testing"
+
+	api "github.com/coreos-inc/vault-operator/pkg/apis/vault/v1alpha1"
+	"github.com/coreos-inc/vault-operator/pkg/client"
+	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WaitForCluster waits for all available nodes of a cluster to appear in the vault CR status
+// Returns the updated vault cluster and the TLS configuration to use for vault clients interacting with the cluster
+func WaitForCluster(t *testing.T, kubeClient kubernetes.Interface, vaultsCRClient client.Vaults, vaultCR *api.VaultService) (*api.VaultService, *vaultapi.TLSConfig) {
+	vaultCR, err := WaitAvailableVaultsUp(t, vaultsCRClient, int(vaultCR.Spec.Nodes), 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
+	}
+
+	tlsConfig, err := k8sutil.VaultTLSFromSecret(kubeClient, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to read TLS config for vault client: %v", err)
+	}
+	return vaultCR, tlsConfig
+}
+
+// InitializeVault initializes the specified vault cluster and waits for all available nodes to appear as sealed.
+// Requires established portforwarded connections to the vault pods
+// Returns the updated vault cluster and the initialization response which includes the unseal key
+func InitializeVault(t *testing.T, vaultsCRClient client.Vaults, vault *api.VaultService, conn *Connection) (*api.VaultService, *vaultapi.InitResponse) {
+	initOpts := &vaultapi.InitRequest{SecretShares: 1, SecretThreshold: 1}
+	initResp, err := conn.VClient.Sys().Init(initOpts)
+	if err != nil {
+		t.Fatalf("failed to initialize vault: %v", err)
+	}
+	// Wait until initialized nodes to be reflected on status.SealedNodes
+	vault, err = WaitSealedVaultsUp(t, vaultsCRClient, int(vault.Spec.Nodes), 6, vault)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
+	}
+	return vault, initResp
+}
+
+// UnsealVaultNode unseals the specified vault pod by portforwarding to it via its vault client
+func UnsealVaultNode(unsealKey string, conn *Connection) error {
+	unsealResp, err := conn.VClient.Sys().Unseal(unsealKey)
+	if err != nil {
+		return fmt.Errorf("failed to unseal vault: %v", err)
+	}
+	if unsealResp.Sealed {
+		return fmt.Errorf("failed to unseal vault: unseal response still shows vault as sealed")
+	}
+	return nil
+}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,114 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
+	"github.com/coreos-inc/vault-operator/test/e2e/framework"
+)
+
+func TestUpgradeVault(t *testing.T) {
+	f := framework.Global
+	vaultCR, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 2))
+	if err != nil {
+		t.Fatalf("failed to create vault cluster: %v", err)
+	}
+	defer func() {
+		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, vaultCR); err != nil {
+			t.Fatalf("failed to delete vault cluster: %v", err)
+		}
+	}()
+	vaultCR, tlsConfig := e2eutil.WaitForCluster(t, f.KubeClient, f.VaultsCRClient, vaultCR)
+
+	conns := map[string]*e2eutil.Connection{}
+	if err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, conns, tlsConfig, vaultCR.Status.AvailableNodes...); err != nil {
+		t.Fatalf("failed to portforward and create vault clients: %v", err)
+	}
+	defer func() {
+		for podName, conn := range conns {
+			if err := conn.PF.StopForwarding(podName, f.Namespace); err != nil {
+				t.Errorf("failed to stop port forwarding to pod(%v): %v", podName, err)
+			}
+		}
+	}()
+
+	// Initialize vault via the 1st available node
+	podName := vaultCR.Status.AvailableNodes[0]
+	conn := e2eutil.GetConnOrFail(t, podName, conns)
+	vaultCR, initResp := e2eutil.InitializeVault(t, f.VaultsCRClient, vaultCR, conn)
+
+	// Unseal the 1st vault node and wait for it to become active
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
+	}
+	vaultCR, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for any node to become active: %v", err)
+	}
+
+	// Unseal the 2nd vault node and wait for it to become standby
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err = e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
+	}
+	vaultCR, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become standby: %v", err)
+	}
+
+	// Upgrade vault version
+	newVersion := "0.8.0-1"
+	vaultCR, err = e2eutil.UpdateVersion(t, f.VaultsCRClient, vaultCR, newVersion)
+	if err != nil {
+		t.Fatalf("failed to update vault version: %v", err)
+	}
+
+	// Check for 2 sealed nodes
+	vaultCR, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 2, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for updated sealed vault nodes: %v", err)
+	}
+
+	// Portforward to and unseal the sealed nodes
+	if err = e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, conns, tlsConfig, vaultCR.Status.SealedNodes...); err != nil {
+		t.Fatalf("failed to portforward and create vault clients: %v", err)
+	}
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err = e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
+	}
+	podName = vaultCR.Status.SealedNodes[1]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err = e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
+	}
+
+	// Wait for only 2 available nodes, i.e the old active node steps down and is removed
+	vaultCR, err = e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 2, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for nodes to become available: %v", err)
+	}
+
+	// Check that 1 active and 1 standby are of the updated version
+	vaultCR, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for any node to become active: %v", err)
+	}
+	err = e2eutil.CheckVersionReached(t, f.KubeClient, newVersion, 6, vaultCR, vaultCR.Status.ActiveNode)
+	if err != nil {
+		t.Fatalf("failed to wait for active node to become updated: %v", err)
+	}
+
+	vaultCR, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, vaultCR)
+	if err != nil {
+		t.Fatalf("failed to wait for vault nodes to become standby: %v", err)
+	}
+	err = e2eutil.CheckVersionReached(t, f.KubeClient, newVersion, 6, vaultCR, vaultCR.Status.StandbyNodes...)
+	if err != nil {
+		t.Fatalf("failed to wait for standby nodes to become updated: %v", err)
+	}
+}


### PR DESCRIPTION
Added e2e test for vault version upgrade of a 2 node HA cluster.

Also abstracted unsealing a vault pod into a util `UnsealVaultNode`.

/cc @hongchaodeng 