### PR TITLE
e2e: use e2eutils to clean up basic and scale tests

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -4,96 +4,60 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/framework"
-
-	vaultapi "github.com/hashicorp/vault/api"
 )
 
 func TestCreateHAVault(t *testing.T) {
 	f := framework.Global
-	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 2))
+	vaultCR, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 2))
 	if err != nil {
 		t.Fatalf("failed to create vault cluster: %v", err)
 	}
 	defer func() {
-		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, testVault); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, vaultCR); err != nil {
 			t.Fatalf("failed to delete vault cluster: %v", err)
 		}
 	}()
 
-	vault, err := e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
-	if err != nil {
-		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
-	}
+	vaultCR, tlsConfig := e2eutil.WaitForCluster(t, f.KubeClient, f.VaultsCRClient, vaultCR)
 
-	tlsConfig, err := k8sutil.VaultTLSFromSecret(f.KubeClient, vault)
-	if err != nil {
-		t.Fatalf("failed to read TLS config for vault client: %v", err)
-	}
-
-	conns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vault.Status.AvailableNodes...)
+	conns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vaultCR.Status.AvailableNodes...)
 	if err != nil {
 		t.Fatalf("failed to portforward and create vault clients: %v", err)
 	}
 	defer e2eutil.CleanupConnections(t, f.Namespace, conns)
 
-	initOpts := &vaultapi.InitRequest{
-		SecretShares:    1,
-		SecretThreshold: 1,
-	}
-
 	// Init vault via the first available node
-	podName := vault.Status.AvailableNodes[0]
-	conn, ok := conns[podName]
-	if !ok {
-		t.Fatalf("failed to find vault client for pod (%v)", podName)
-	}
-	initResp, err := conn.VClient.Sys().Init(initOpts)
-	if err != nil {
-		t.Fatalf("failed to initialize vault: %v", err)
-	}
-
-	vault, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 2, 6, testVault)
-	if err != nil {
-		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
-	}
+	podName := vaultCR.Status.AvailableNodes[0]
+	conn := e2eutil.GetConnOrFail(t, podName, conns)
+	vaultCR, initResp := e2eutil.InitializeVault(t, f.VaultsCRClient, vaultCR, conn)
 
 	// Unseal the 1st vault node and wait for it to become active
-	unsealResp, err := conn.VClient.Sys().Unseal(initResp.Keys[0])
-	if err != nil {
-		t.Fatalf("failed to unseal vault: %v", err)
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
 	}
-	if unsealResp.Sealed {
-		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
-	}
-	vault, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, testVault)
+	vaultCR, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to wait for any node to become active: %v", err)
 	}
 
 	// Unseal the 2nd vault node(the remaining sealed node) and wait for it to become standby
-	podName = vault.Status.SealedNodes[0]
-	conn, ok = conns[podName]
-	if !ok {
-		t.Fatalf("failed to find vault client for pod (%v)", podName)
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, conns)
+	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
 	}
-	unsealResp, err = conn.VClient.Sys().Unseal(initResp.Keys[0])
-	if err != nil {
-		t.Fatalf("failed to unseal vault: %v", err)
-	}
-	if unsealResp.Sealed {
-		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
-	}
-	vault, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	vaultCR, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become standby: %v", err)
 	}
 
 	// Write secret to active node
-	podName = vault.Status.ActiveNode
-	conn, ok = conns[podName]
+	podName = vaultCR.Status.ActiveNode
+	conn, ok := conns[podName]
 	if !ok {
 		t.Fatalf("failed to find vault client for pod (%v)", podName)
 	}

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -3,67 +3,42 @@ package e2e
 import (
 	"testing"
 
-	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
 	"github.com/coreos-inc/vault-operator/test/e2e/framework"
-
-	vaultapi "github.com/hashicorp/vault/api"
 )
 
 func TestScaleUp(t *testing.T) {
 	f := framework.Global
-	testVault, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 1))
+	vaultCR, err := e2eutil.CreateCluster(t, f.VaultsCRClient, e2eutil.NewCluster("test-vault-", f.Namespace, 1))
 	if err != nil {
 		t.Fatalf("failed to create vault cluster: %v", err)
 	}
 	defer func() {
-		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, testVault); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.VaultsCRClient, vaultCR); err != nil {
 			t.Fatalf("failed to delete vault cluster: %v", err)
 		}
 	}()
 
-	vault, err := e2eutil.WaitAvailableVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
-	if err != nil {
-		t.Fatalf("failed to wait for cluster nodes to become available: %v", err)
-	}
+	vaultCR, tlsConfig := e2eutil.WaitForCluster(t, f.KubeClient, f.VaultsCRClient, vaultCR)
 
-	tlsConfig, err := k8sutil.VaultTLSFromSecret(f.KubeClient, vault)
-	if err != nil {
-		t.Fatalf("failed to read TLS config for vault client: %v", err)
-	}
-
-	startingConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vault.Status.AvailableNodes...)
+	startingConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vaultCR.Status.AvailableNodes...)
 	if err != nil {
 		t.Fatalf("failed to portforward and create vault clients: %v", err)
 	}
 	defer e2eutil.CleanupConnections(t, f.Namespace, startingConns)
 
 	// Init vault via the first available node
-	initOpts := &vaultapi.InitRequest{SecretShares: 1, SecretThreshold: 1}
-	podName := vault.Status.AvailableNodes[0]
-	conn, ok := startingConns[podName]
-	if !ok {
-		t.Fatalf("failed to find vault client for pod (%v)", podName)
-	}
-	initResp, err := conn.VClient.Sys().Init(initOpts)
-	if err != nil {
-		t.Fatalf("failed to initialize vault: %v", err)
-	}
-
-	vault, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
-	if err != nil {
-		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
-	}
+	podName := vaultCR.Status.AvailableNodes[0]
+	conn := e2eutil.GetConnOrFail(t, podName, startingConns)
+	vaultCR, initResp := e2eutil.InitializeVault(t, f.VaultsCRClient, vaultCR, conn)
 
 	// Unseal the vault node and wait for it to become active
-	unsealResp, err := conn.VClient.Sys().Unseal(initResp.Keys[0])
-	if err != nil {
-		t.Fatalf("failed to unseal vault: %v", err)
+	podName = vaultCR.Status.SealedNodes[0]
+	conn = e2eutil.GetConnOrFail(t, podName, startingConns)
+	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
 	}
-	if unsealResp.Sealed {
-		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
-	}
-	vault, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, testVault)
+	vaultCR, err = e2eutil.WaitActiveVaultsUp(t, f.VaultsCRClient, 6, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to wait for any node to become active: %v", err)
 	}
@@ -71,17 +46,17 @@ func TestScaleUp(t *testing.T) {
 	// TODO: Write secret to active node, read secret from new node later
 
 	// Resize cluster to 2 nodes
-	vault, err = e2eutil.ResizeCluster(t, f.VaultsCRClient, vault, 2)
+	vaultCR, err = e2eutil.ResizeCluster(t, f.VaultsCRClient, vaultCR, 2)
 	if err != nil {
 		t.Fatalf("failed to resize vault cluster: %v", err)
 	}
 
 	// Wait for 1 unsealed node and create a vault client for it
-	vault, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	vaultCR, err = e2eutil.WaitSealedVaultsUp(t, f.VaultsCRClient, 1, 6, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
 	}
-	podName = vault.Status.SealedNodes[0]
+	podName = vaultCR.Status.SealedNodes[0]
 	scaledConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, podName)
 	if err != nil {
 		t.Fatalf("failed to portforward and create vault clients: %v", err)
@@ -89,18 +64,11 @@ func TestScaleUp(t *testing.T) {
 	defer e2eutil.CleanupConnections(t, f.Namespace, scaledConns)
 
 	// Unseal the new node and wait for it to become standby
-	conn, ok = scaledConns[podName]
-	if !ok {
-		t.Fatalf("failed to find vault client for pod (%v)", podName)
+	conn = e2eutil.GetConnOrFail(t, podName, scaledConns)
+	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
+		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
 	}
-	unsealResp, err = conn.VClient.Sys().Unseal(initResp.Keys[0])
-	if err != nil {
-		t.Fatalf("failed to unseal vault: %v", err)
-	}
-	if unsealResp.Sealed {
-		t.Fatal("failed to unseal vault: unseal response still shows vault as sealed")
-	}
-	vault, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, testVault)
+	vaultCR, err = e2eutil.WaitStandbyVaultsUp(t, f.VaultsCRClient, 1, 6, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become standby: %v", err)
 	}


### PR DESCRIPTION
Use helper utils like `WaitForCluster()` `InitializeVault()` and `UnsealVaultNode()` to shorten the common vault setup code in `TestCreateHAVault` and `TestScaleUp`.
/cc @hongchaodeng 