### PR TITLE
upgradetest: framework for upgrade tests

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -40,6 +40,24 @@ function e2e_pass {
 	  /e2etest/bin/e2e.test -test.timeout=30m --kubeconfig=/e2etest/kubeconfig --operator-image=${OPERATOR_IMAGE} --namespace=${TEST_NAMESPACE}
 }
 
+function upgrade_pass {
+	# Setup test namespace, RBAC rules and pull secret
+	source hack/ci/utils.sh
+	trap cleanup_all EXIT
+	if setup_all ; then
+		echo "Namespace, RBAC and pull secret setup success! ==="
+	else
+		echo "Namespace, RBAC and pull secret setup fail! ==="
+		exit 1
+	fi
+
+	cp ${KUBECONFIG} _output/kubeconfig
+	# TODO: Run upgrade tests in docker
+	go test -v "./test/e2e/upgradetest" -timeout 30m --race --kubeconfig=${KUBECONFIG} --namespace=${TEST_NAMESPACE} \
+		--old-vop-image=$UPGRADE_FROM \
+		--new-vop-image=$UPGRADE_TO
+}
+
 for p in $PASSES; do
 	${p}_pass
 done

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -1,0 +1,131 @@
+package framework
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/coreos-inc/vault-operator/pkg/client"
+	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
+	"github.com/coreos-inc/vault-operator/test/e2e/e2eutil"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd-operator/pkg/util/probe"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	// The global framework variable used by all upgrade tests
+	Global           *Framework
+	etcdOperatorName = "etcd-operator"
+)
+
+// Framework struct contains the various clients and other information needed to run the upgrade tests
+type Framework struct {
+	KubeClient     kubernetes.Interface
+	Config         *restclient.Config
+	VaultsCRClient client.Vaults
+	Namespace      string
+	oldVOPImage    string
+	newVOPImage    string
+	eopImage       string
+}
+
+// Setup initializes the Global framework by initializing necessary clients and sets up the etcd-operator
+func Setup() error {
+	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
+	oldVOPImage := flag.String("old-vop-image", "", "operator image, e.g. quay.io/coreos/vault-operator-dev:latest")
+	newVOPImage := flag.String("new-vop-image", "", "operator image, e.g. quay.io/coreos/vault-operator-dev:master")
+	eopImage := flag.String("etcd-operator-image", "quay.io/coreos/etcd-operator:latest", "etcd operator image, e.g. quay.io/coreos/etcd-operator:latest")
+	ns := flag.String("namespace", "", "e2e test namespace")
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to build config from kubeconfig: %v", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("faild to create kube client: %v", err)
+	}
+	vaultsCRClient, err := client.NewCRClient(config)
+	if err != nil {
+		return fmt.Errorf("failed to create CR client: %v", err)
+	}
+
+	Global = &Framework{
+		KubeClient:     kubeClient,
+		Config:         config,
+		VaultsCRClient: vaultsCRClient,
+		Namespace:      *ns,
+		oldVOPImage:    *oldVOPImage,
+		newVOPImage:    *newVOPImage,
+		eopImage:       *eopImage,
+	}
+
+	if err := Global.deployEtcdOperatorPod(); err != nil {
+		return fmt.Errorf("failed to setup etcd operator: %v", err)
+	}
+	return nil
+}
+
+// TearDown removes the etcd-operator pod
+func TearDown() error {
+	err := Global.KubeClient.CoreV1().Pods(Global.Namespace).Delete(etcdOperatorName, k8sutil.CascadeDeleteBackground())
+	if err != nil {
+		return fmt.Errorf("failed to delete pod: %v", err)
+	}
+	Global = nil
+	logrus.Info("e2e teardown successfully")
+	return nil
+}
+
+func (f *Framework) deployEtcdOperatorPod() error {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   etcdOperatorName,
+			Labels: e2eutil.PodLabelForOperator(etcdOperatorName),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            etcdOperatorName,
+					Image:           f.eopImage,
+					ImagePullPolicy: v1.PullAlways,
+					Env: []v1.EnvVar{
+						{
+							Name:      "MY_POD_NAMESPACE",
+							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+						},
+						{
+							Name:      "MY_POD_NAME",
+							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+						},
+					},
+					ReadinessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path: probe.HTTPReadyzEndpoint,
+								Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+							},
+						},
+						InitialDelaySeconds: 3,
+						PeriodSeconds:       3,
+						FailureThreshold:    3,
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	_, err := f.KubeClient.CoreV1().Pods(f.Namespace).Create(pod)
+	if err != nil {
+		return fmt.Errorf("failed to create pod: %v", err)
+	}
+	return e2eutil.WaitUntilOperatorReady(f.KubeClient, f.Namespace, etcdOperatorName)
+}

--- a/test/e2e/upgradetest/main_test.go
+++ b/test/e2e/upgradetest/main_test.go
@@ -1,0 +1,25 @@
+package upgradetest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coreos-inc/vault-operator/test/e2e/upgradetest/framework"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	if err := framework.Setup(); err != nil {
+		logrus.Errorf("fail to setup framework: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := framework.TearDown(); err != nil {
+		logrus.Errorf("fail to teardown framework: %v", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
Added the basic framework for upgrade tests. 
Currently the framework only sets up the etcd-operator pod needed for all upgrade tests.

/cc @hongchaodeng 