### PR TITLE
*: support readiness probe

### DIFF
--- a/cmd/vault-operator/main.go
+++ b/cmd/vault-operator/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"runtime"
 	"time"
 
 	"github.com/coreos-inc/vault-operator/pkg/operator"
 	"github.com/coreos-inc/vault-operator/pkg/util/k8sutil"
+	"github.com/coreos-inc/vault-operator/pkg/util/probe"
 	"github.com/coreos-inc/vault-operator/version"
+
+	"github.com/Sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -16,8 +20,6 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
-
-	"github.com/Sirupsen/logrus"
 )
 
 func main() {
@@ -40,6 +42,9 @@ func main() {
 		panic(err)
 	}
 	kubecli := kubernetes.NewForConfigOrDie(kubecfg)
+
+	http.HandleFunc(probe.HTTPReadyzEndpoint, probe.ReadyzHandler)
+	go http.ListenAndServe("0.0.0.0:8080", nil)
 
 	id, err := os.Hostname()
 	if err != nil {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	api "github.com/coreos-inc/vault-operator/pkg/apis/vault/v1alpha1"
+	"github.com/coreos-inc/vault-operator/pkg/util/probe"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -37,6 +38,8 @@ func (v *Vaults) run(ctx context.Context) {
 		logrus.Error("Timed out waiting for caches to sync")
 		return
 	}
+
+	probe.SetReady()
 
 	const numWorkers = 1
 	for i := 0; i < numWorkers; i++ {

--- a/pkg/util/probe/readyz.go
+++ b/pkg/util/probe/readyz.go
@@ -1,0 +1,40 @@
+package probe
+
+import (
+	"net/http"
+	"sync"
+)
+
+const (
+	// HTTPReadyzEndpoint is the endpoint at which the readiness probe is supported
+	HTTPReadyzEndpoint = "/readyz"
+)
+
+var (
+	mu    sync.Mutex
+	ready = false
+)
+
+// SetReady sets the ready condition to true, which causes the handler to respond with an OK status to readiness probes
+func SetReady() {
+	mu.Lock()
+	ready = true
+	mu.Unlock()
+}
+
+// ReadyzHandler writes back the HTTP status code 200 if the operator is ready, and 500 otherwise
+func ReadyzHandler(w http.ResponseWriter, r *http.Request) {
+	if isReady() {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+// isReady returns the status of the ready variable
+func isReady() bool {
+	mu.Lock()
+	isReady := ready
+	mu.Unlock()
+	return isReady
+}


### PR DESCRIPTION
Added support for operator readiness probe. 
This will be needed by the upgrade tests to check if the operator is ready after creation and upgrade.

The operator sets itself to ready after running the informer to watch for vault CR events.

/cc @hongchaodeng 