### PR TITLE
*: group nodes in vault status

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In this example, a Vault cluster is configured with two nodes in high availabili
 4. Verify that the Vault nodes can be viewed in the "vault" resource status:
 
       ```
-      $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.sealedNodes}'
+      $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.sealed}'
       [example-vault-1003480066-b757c example-vault-1003480066-jzmwd]
       ```
 

--- a/doc/design/upgrade.md
+++ b/doc/design/upgrade.md
@@ -9,7 +9,7 @@ We will add following fields to Vault status:
 
 ```
 // PodNames of the up-to-date Vault Pods
-UpdatedNodes []string
+Updated []string
 ```
 
 The status update goroutine will take care of it.

--- a/doc/user/kubernetes-auth-backend.md
+++ b/doc/user/kubernetes-auth-backend.md
@@ -22,7 +22,7 @@ In order to enable and configure the auth backend with the necessary roles and p
 1. Configure port forwarding between the local machine and the active Vault node:
    
     ```sh
-    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.activeNode}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 2. Open a new terminal. Use this terminal for the rest of this guide.

--- a/doc/user/vault.md
+++ b/doc/user/vault.md
@@ -15,7 +15,7 @@ Initialize a new Vault cluster before performing any operations.
 1. Configure port forwarding between the local machine and the first sealed Vault node:
 
     ```sh
-    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.sealedNodes[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.sealed[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 2. Open a new terminal.
@@ -62,13 +62,13 @@ The first node that is unsealed in a multi-node vault cluster will become the ac
 1. Check the active Vault node:
 
     ```sh
-    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.activeNode}'
+    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.active}'
     ```
 
 2. Configure port forwarding between the local machine and the active Vault node:
 
     ```sh
-    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.activeNode}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 3. Open a new terminal.
@@ -119,7 +119,7 @@ A standby Vault node is initialized and unsealed, but does not hold the leader e
 2. Verify that the node becomes standby:
 
     ```sh
-    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.standbyNodes}'
+    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.standby}'
     [example-vault-1003480066-jzmwd]
     ```
 
@@ -134,7 +134,7 @@ To see how it works, perform the following:
 1. Terminate the active Vault node:
 
     ```
-    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.activeNode}' | xargs -0 -I {} kubectl -n vault-services delete po {}
+    kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services delete po {}
     ```
 
     The standby node becomes active.
@@ -142,7 +142,7 @@ To see how it works, perform the following:
 2. Verify that the node is active:
 
     ```
-    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.activeNode}'
+    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.active}'
     example-vault-1003480066-jzmwd
     ```
 
@@ -164,14 +164,14 @@ To see how it works, perform the following:
 2. Verify that a new Vault node is created:
 
     ```
-    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.availableNodes}'
+    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.available}'
     [example-vault-1003480066-jzmwd example-vault-994933690-h066h]
     ```
 
 3. Verify that the newly created Vault node is sealed:
 
     ```
-    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.sealedNodes}'
+    $ kubectl -n vault-services get vault example-vault -o jsonpath='{.status.nodes.sealed}'
     [example-vault-994933690-h066h]
     ```
 

--- a/hack/helper/create-cluster.sh
+++ b/hack/helper/create-cluster.sh
@@ -34,7 +34,7 @@ while [ "${NUM_SEALED}" -ne "${NUM_NODES}" ]
 do
     sleep ${RETRY_INTERVAL}
 
-    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.sealedNodes}' | sed 's/^.\(.*\).$/\1/' )
+    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
     IFS=' ' read -r -a SEALED_ARRAY <<< "${SEALED_NODES}"
     NUM_SEALED=${#SEALED_ARRAY[@]}
 done
@@ -62,7 +62,7 @@ while [ -z "${ACT_NODE}" ]
 do
     echo "Waiting for active node to show up"
     sleep ${RETRY_INTERVAL}
-    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.activeNode}')
+    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
 done
 
 echo "Vault cluster setup complete!"

--- a/hack/helper/unseal.sh
+++ b/hack/helper/unseal.sh
@@ -12,7 +12,7 @@ set -o pipefail
 : ${UNSEAL_KEY:?"Need to set UNSEAL_KEY"}
 
 # Get all sealed nodes
-SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.sealedNodes}' | sed 's/^.\(.*\).$/\1/' )
+SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
 if [ "${SEALED_NODES}" == "nil" ]; then
     echo "No sealed nodes found"
     exit 0

--- a/hack/helper/upgrade.sh
+++ b/hack/helper/upgrade.sh
@@ -26,7 +26,7 @@ NUM_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{
 # Check the cluster conditions before upgrade can be performed: 1 active and 0 sealed nodes
 # Check for 1 active node
 # There must be an active node before upgrade in order for N sealed nodes to show up after upgrade. Otherwise if N=1 and it is sealed then after upgrade there will be 2 sealed nodes.
-ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.activeNode}')
+ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
 if [ -z "$ACT_NODE" ]; then
     echo "Vault cluster must have an active node before upgrading"
     exit 1
@@ -45,7 +45,7 @@ while [ "${NUM_SEALED}" -ne "${NUM_NODES}" ]
 do
     sleep ${RETRY_INTERVAL}
 
-    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.sealedNodes}' | sed 's/^.\(.*\).$/\1/' )
+    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
     IFS=' ' read -r -a SEALED_ARRAY <<< "${SEALED_NODES}"
     NUM_SEALED=${#SEALED_ARRAY[@]}
 done
@@ -62,7 +62,7 @@ do
     sleep ${RETRY_INTERVAL}
 
     # Get the active node name
-    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.activeNode}')
+    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
     if [ -z "$ACT_NODE" ]; then
         echo "No active node found in CR status. Retrying"
         continue

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -81,27 +81,32 @@ type VaultServiceStatus struct {
 	// It's the same on client LB service and vault nodes.
 	ClientPort int `json:"clientPort,omitempty"`
 
+	// Nodes represents the vault nodes grouped by their status
+	Nodes Nodes `json:"nodes"`
+}
+
+type Nodes struct {
 	// PodNames of available nodes.
 	// Avaliable node is a running Vault pod, but not necessarily unsealed and ready
 	// to serve requests.
-	AvailableNodes []string `json:"availableNodes"`
+	Available []string `json:"available"`
 
 	// PodNames of the active Vault node. Active node is unsealed.
 	// Only active node can serve requests.
 	// Vault service only points to the active node.
-	ActiveNode string `json:"activeNode"`
+	Active string `json:"active"`
 
 	// PodNames of the standby Vault nodes. Standby nodes are unsealed.
 	// Standby nodes do not process requests, and instead redirect to the active Vault.
-	StandbyNodes []string `json:"standbyNodes"`
+	Standby []string `json:"standby"`
 
 	// PodNames of Sealed Vault nodes. Sealed nodes MUST be manually unsealed to
 	// become standby or leader.
-	SealedNodes []string `json:"sealedNodes"`
+	Sealed []string `json:"sealed"`
 
 	// PodNames of updated Vault nodes. Updated means the Vault container image version
 	// matches the spec's version.
-	UpdatedNodes []string `json:"updatedNodes"`
+	Updated []string `json:"updated"`
 }
 
 // DefaultVaultClientTLSSecretName returns the name of the default vault client TLS secret

--- a/pkg/operator/vault_status.go
+++ b/pkg/operator/vault_status.go
@@ -66,9 +66,9 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, vr *api.VaultSer
 	}
 
 	var sealNodes []string
-	var availableNodes []string
+	var available []string
 	var standByNodes []string
-	var updatedNodes []string
+	var updated []string
 	inited := false
 	// If it can't talk to any vault pod, we are not going to change the status.
 	changed := false
@@ -93,14 +93,14 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, vr *api.VaultSer
 
 		changed = true
 
-		availableNodes = append(availableNodes, p.GetName())
+		available = append(available, p.GetName())
 		if k8sutil.IsVaultVersionMatch(p.Spec, vr.Spec) {
-			updatedNodes = append(updatedNodes, p.GetName())
+			updated = append(updated, p.GetName())
 		}
 
 		// TODO: add to vaultutil?
 		if hr.Initialized && !hr.Sealed && !hr.Standby {
-			s.ActiveNode = p.GetName()
+			s.Nodes.Active = p.GetName()
 		}
 		if hr.Initialized && !hr.Sealed && hr.Standby {
 			standByNodes = append(standByNodes, p.GetName())
@@ -117,11 +117,11 @@ func (vs *Vaults) updateLocalVaultCRStatus(ctx context.Context, vr *api.VaultSer
 		return
 	}
 
-	s.AvailableNodes = availableNodes
-	s.StandbyNodes = standByNodes
-	s.SealedNodes = sealNodes
+	s.Nodes.Available = available
+	s.Nodes.Standby = standByNodes
+	s.Nodes.Sealed = sealNodes
 	s.Initialized = inited
-	s.UpdatedNodes = updatedNodes
+	s.Nodes.Updated = updated
 }
 
 // updateVaultCRStatus updates the status field of the Vault CR.

--- a/test/e2e/e2eutil/vault_util.go
+++ b/test/e2e/e2eutil/vault_util.go
@@ -36,7 +36,7 @@ func InitializeVault(t *testing.T, vaultsCRClient client.Vaults, vault *api.Vaul
 	if err != nil {
 		t.Fatalf("failed to initialize vault: %v", err)
 	}
-	// Wait until initialized nodes to be reflected on status.SealedNodes
+	// Wait until initialized nodes to be reflected on status.nodes.Sealed
 	vault, err = WaitSealedVaultsUp(t, vaultsCRClient, int(vault.Spec.Nodes), 6, vault)
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -72,8 +72,8 @@ func WaitUntilVaultConditionTrue(t *testing.T, vaultsCRClient client.Vaults, ret
 // WaitAvailableVaultsUp retries until the desired number of vault nodes are shown as available in the CR status
 func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *api.VaultService) (*api.VaultService, error) {
 	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *api.VaultService) bool {
-		LogfWithTimestamp(t, "available nodes: (%v)", v.Status.AvailableNodes)
-		return len(v.Status.AvailableNodes) == size
+		LogfWithTimestamp(t, "available nodes: (%v)", v.Status.Nodes.Available)
+		return len(v.Status.Nodes.Available) == size
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for available size to become (%v): %v", size, err)
@@ -84,8 +84,8 @@ func WaitAvailableVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, ret
 // WaitSealedVaultsUp retries until the desired number of vault nodes are shown as sealed in the CR status
 func WaitSealedVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *api.VaultService) (*api.VaultService, error) {
 	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *api.VaultService) bool {
-		LogfWithTimestamp(t, "sealed nodes: (%v)", v.Status.SealedNodes)
-		return len(v.Status.SealedNodes) == size
+		LogfWithTimestamp(t, "sealed nodes: (%v)", v.Status.Nodes.Sealed)
+		return len(v.Status.Nodes.Sealed) == size
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for sealed size to become (%v): %v", size, err)
@@ -96,8 +96,8 @@ func WaitSealedVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retrie
 // WaitStandbyVaultsUp retries until the desired number of vault nodes are shown as standby in the CR status
 func WaitStandbyVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retries int, cl *api.VaultService) (*api.VaultService, error) {
 	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *api.VaultService) bool {
-		LogfWithTimestamp(t, "standby nodes: (%v)", v.Status.StandbyNodes)
-		return len(v.Status.StandbyNodes) == size
+		LogfWithTimestamp(t, "standby nodes: (%v)", v.Status.Nodes.Standby)
+		return len(v.Status.Nodes.Standby) == size
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for standby size to become (%v): %v", size, err)
@@ -108,8 +108,8 @@ func WaitStandbyVaultsUp(t *testing.T, vaultsCRClient client.Vaults, size, retri
 // WaitActiveVaultsUp retries until there is 1 active node in the CR status
 func WaitActiveVaultsUp(t *testing.T, vaultsCRClient client.Vaults, retries int, cl *api.VaultService) (*api.VaultService, error) {
 	vault, err := WaitUntilVaultConditionTrue(t, vaultsCRClient, retries, cl, func(v *api.VaultService) bool {
-		LogfWithTimestamp(t, "active node: (%v)", v.Status.ActiveNode)
-		return len(v.Status.ActiveNode) != 0
+		LogfWithTimestamp(t, "active node: (%v)", v.Status.Nodes.Active)
+		return len(v.Status.Nodes.Active) != 0
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for any node to become active: %v", err)
@@ -214,8 +214,8 @@ func WaitUntilActiveIsFrom(t *testing.T, vaultsCRClient client.Vaults, retries i
 		if err != nil {
 			return false, fmt.Errorf("failed to get CR: %v", err)
 		}
-		LogfWithTimestamp(t, "active node: (%v)", vault.Status.ActiveNode)
-		if !presentIn(vault.Status.ActiveNode, targetVaultPods...) {
+		LogfWithTimestamp(t, "active node: (%v)", vault.Status.Nodes.Active)
+		if !presentIn(vault.Status.Nodes.Active, targetVaultPods...) {
 			return false, nil
 		}
 		return true, nil
@@ -235,8 +235,8 @@ func WaitUntilStandbyAreFrom(t *testing.T, vaultsCRClient client.Vaults, retries
 		if err != nil {
 			return false, fmt.Errorf("failed to get CR: %v", err)
 		}
-		LogfWithTimestamp(t, "standby nodes: (%v)", vault.Status.StandbyNodes)
-		for _, standbyNode := range vault.Status.StandbyNodes {
+		LogfWithTimestamp(t, "standby nodes: (%v)", vault.Status.Nodes.Standby)
+		for _, standbyNode := range vault.Status.Nodes.Standby {
 			if !presentIn(standbyNode, targetVaultPods...) {
 				return false, nil
 			}
@@ -258,8 +258,8 @@ func WaitUntilAvailableAreFrom(t *testing.T, vaultsCRClient client.Vaults, retri
 		if err != nil {
 			return false, fmt.Errorf("failed to get CR: %v", err)
 		}
-		LogfWithTimestamp(t, "available nodes: (%v)", vault.Status.AvailableNodes)
-		for _, availableNode := range vault.Status.AvailableNodes {
+		LogfWithTimestamp(t, "available nodes: (%v)", vault.Status.Nodes.Available)
+		for _, availableNode := range vault.Status.Nodes.Available {
 			if !presentIn(availableNode, targetVaultPods...) {
 				return false, nil
 			}

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -43,19 +43,19 @@ func TestUpgradeAndScaleVault(t *testing.T) {
 	}(vaultCR)
 	vaultCR, tlsConfig := e2eutil.WaitForCluster(t, f.KubeClient, f.VaultsCRClient, vaultCR)
 
-	startingConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vaultCR.Status.AvailableNodes...)
+	startingConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, vaultCR.Status.Nodes.Available...)
 	if err != nil {
 		t.Fatalf("failed to portforward and create vault clients: %v", err)
 	}
 	defer e2eutil.CleanupConnections(t, f.Namespace, startingConns)
 
 	// Init vault via the first available node
-	podName := vaultCR.Status.AvailableNodes[0]
+	podName := vaultCR.Status.Nodes.Available[0]
 	conn := e2eutil.GetConnOrFail(t, podName, startingConns)
 	vaultCR, initResp := e2eutil.InitializeVault(t, f.VaultsCRClient, vaultCR, conn)
 
 	// Unseal the vault node and wait for it to become active
-	podName = vaultCR.Status.SealedNodes[0]
+	podName = vaultCR.Status.Nodes.Sealed[0]
 	conn = e2eutil.GetConnOrFail(t, podName, startingConns)
 	if err := e2eutil.UnsealVaultNode(initResp.Keys[0], conn); err != nil {
 		t.Fatalf("failed to unseal vault node(%v): %v", podName, err)
@@ -80,7 +80,7 @@ func TestUpgradeAndScaleVault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)
 	}
-	podName = vaultCR.Status.SealedNodes[0]
+	podName = vaultCR.Status.Nodes.Sealed[0]
 	scaledConns, err := e2eutil.PortForwardVaultClients(f.KubeClient, f.Config, f.Namespace, tlsConfig, podName)
 	if err != nil {
 		t.Fatalf("failed to portforward and create vault clients: %v", err)


### PR DESCRIPTION
The vault status now groups all the different node status types together.
```yaml
status:
    clientPort: 8200
    initialized: true
    nodes:
      active: example-vault-1395307387-682n0
      available:
      - example-vault-1395307387-682n0
      - example-vault-1395307387-w7smw
      sealed: null
      standby:
      - example-vault-1395307387-w7smw
      updated:
      - example-vault-1395307387-682n0
      - example-vault-1395307387-w7smw
    serviceName: example-vault
```