### PR TITLE
doc: fix 'example' to 'example-vault'

### DIFF
--- a/doc/user/ingress.md
+++ b/doc/user/ingress.md
@@ -6,7 +6,7 @@ Before beginning, create a Vault cluster that is initialized and unsealed. Use t
 
 ### Assumptions
 
-* This example assumes a Vault cluster named `example` in the namespace `default` whose service is accessible at `https://example.default.svc:8200` from inside the cluster.
+* This example assumes a Vault cluster named `example-vault` in the namespace `default` whose service is accessible at `https://example-vault.default.svc:8200` from inside the cluster.
 
 * The Ingress hostname used to access the Vault service will be `vault.ingress.staging.core-os.net`.
 
@@ -57,7 +57,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: example
+              serviceName: example-vault
               servicePort: 8200
 ```
 

--- a/doc/user/kubernetes-auth-backend.md
+++ b/doc/user/kubernetes-auth-backend.md
@@ -23,7 +23,7 @@ To enable and configure the auth backend with the necessary roles and policies, 
 1. Configure port forwarding between the local machine and the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 2. Open a new terminal. Use this terminal for the rest of this guide.

--- a/doc/user/tls_setup.md
+++ b/doc/user/tls_setup.md
@@ -18,7 +18,7 @@ For example, create a Vault cluster with no TLS secrets specified using the foll
 apiVersion: "vault.security.coreos.com/v1alpha1"
 kind: "VaultService"
 metadata:
-  name: example
+  name: example-vault
 spec:
   nodes: 1
 ```
@@ -28,8 +28,8 @@ The following default secrets are generated for the above Vault cluster:
 ```
 $ kubectl get secrets
 NAME                                        TYPE                                  DATA      AGE
-example-default-vault-client-tls      Opaque                                1         1m
-example-default-vault-server-tls      Opaque                                2         1m
+example-vault-default-vault-client-tls      Opaque                                1         1m
+example-vault-default-vault-server-tls      Opaque                                2         1m
 ```
 
 ## Using custom TLS assets

--- a/doc/user/upgrade.md
+++ b/doc/user/upgrade.md
@@ -19,7 +19,7 @@ Create the following Vault CR to use as the basis for the upgrade:
 apiVersion: "vault.security.coreos.com/v1alpha1"
 kind: "VaultService"
 metadata:
-  name: "example"
+  name: "example-vault"
 spec:
   nodes: 2
   version: "0.8.3-0"
@@ -30,7 +30,7 @@ After the Vault cluster is deployed and unsealed, there will be one active and o
 Use `kubectl` to upgrade to Vault `0.9.0-0`:
 
 ```
-kubectl -n default get vault example -o yaml | sed 's/version: 0.8.3-0/version: 0.9.0-0/g' | kubectl apply -f -
+kubectl -n default get vault example-vault -o yaml | sed 's/version: 0.8.3-0/version: 0.9.0-0/g' | kubectl apply -f -
 ```
 
 Vault-operator will upgrade all nodes except the active node to keep service availability.

--- a/doc/user/vault-ui.md
+++ b/doc/user/vault-ui.md
@@ -7,7 +7,7 @@
 * Set up an initialized and unsealed Vault cluster. Use the [create-cluster][create-cluster] script for a quick setup.
 * Install and initialize Helm using the [Helm installation instructions][helm-install]
 
-This example assumes a Vault cluster named `example` in the namespace `default`.
+This example assumes a Vault cluster named `example-vault` in the namespace `default`.
 
 ## Install Vault-UI
 
@@ -76,7 +76,7 @@ ingress:
 resources: {}
 vault:
   auth: TOKEN
-  url: https://example:8200
+  url: https://example-vault:8200
 ```
 
 Use Helm to install Vault-UI within the `default` namespace:

--- a/doc/user/vault.md
+++ b/doc/user/vault.md
@@ -16,7 +16,7 @@ Initialize a new Vault cluster before performing any operations.
 1. Configure port forwarding between the local machine and the first available Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.available[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.available[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 2. Open a new terminal.
@@ -52,7 +52,7 @@ A response confirms that the Vault CLI is ready to interact with the Vault serve
 1. Configure port forwarding between the local machine and the first sealed Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.sealed[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.sealed[0]}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 2. Open a new terminal.
@@ -75,13 +75,13 @@ The first node that is unsealed in a multi-node Vault cluster will become the ac
 1. Check the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}'
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.active}'
     ```
 
 2. Configure port forwarding between the local machine and the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services port-forward {} 8200
     ```
 
 3. Open a new terminal.
@@ -118,9 +118,9 @@ Vault-operator creates [Kubernetes services][k8s-services] for accessing Vault d
 
 The service always exposes the active Vault node. It hides failures by switching the service pointer to the currently active node when failover occurs.
 
-The name and namespace of the service are the same as the Vault resource. For example, if the Vault resource's name is `example`  and the namespace is `default`, the service's name and namespace will also be `example` and `default` respectively.
+The name and namespace of the service are the same as the Vault resource. For example, if the Vault resource's name is `example-vault`  and the namespace is `default`, the service's name and namespace will also be `example-vault` and `default` respectively.
 
-Applications in the Kubernetes pod network can access the service through `https://example.default.svc:8200`.
+Applications in the Kubernetes pod network can access the service through `https://example-vault.default.svc:8200`.
 
 ## Starting a standby Vault node
 
@@ -133,8 +133,8 @@ A standby Vault node is initialized and unsealed, but does not hold the leader e
 2. Verify that the node becomes standby:
 
     ```sh
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.standby}'
-    [example-1003480066-jzmwd]
+    $ kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.standby}'
+    [example-vault-1003480066-jzmwd]
     ```
 
     The setup now contains an active and a standby Vault node.
@@ -148,7 +148,7 @@ To see how it works, terminate the active node, and wait for the standby node to
 1. Terminate the active Vault node:
 
     ```
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services delete po {}
+    kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n vault-services delete po {}
     ```
 
     The standby node becomes active.
@@ -156,8 +156,8 @@ To see how it works, terminate the active node, and wait for the standby node to
 2. Verify that the previous standby node is now active:
 
     ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.active}'
-    example-1003480066-jzmwd
+    $ kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.active}'
+    example-vault-1003480066-jzmwd
     ```
 
 Regular vault operations like reading and writing a secret to the active node should now succeed.
@@ -175,15 +175,15 @@ To see how it works, perform the following:
 2. Verify that a new Vault node is created:
 
     ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.available}'
-    [example-1003480066-jzmwd example-994933690-h066h]
+    $ kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.available}'
+    [example-vault-1003480066-jzmwd example-vault-994933690-h066h]
     ```
 
 3. Verify that the newly created Vault node is sealed:
 
     ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.sealed}'
-    [example-994933690-h066h]
+    $ kubectl -n default get vault example-vault -o jsonpath='{.status.nodes.sealed}'
+    [example-vault-994933690-h066h]
     ```
 
 A new Vault node is created to replace the terminated one. Unseal the node and continue using HA.


### PR DESCRIPTION
[skip ci]
Somehow dismissed in https://github.com/coreos-inc/vault-operator/pull/229
But it changed some vault resource name to `example` and renders docs inconsistent.