### PR TITLE
operator: add logging when a vault CR is created

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -56,6 +56,7 @@ func (v *Vaults) onAddVault(obj interface{}) {
 		panic(err)
 	}
 	v.queue.Add(key)
+	logrus.Infof("Vault CR (%s) is created", key)
 }
 
 func (v *Vaults) onUpdateVault(oldObj, newObj interface{}) {


### PR DESCRIPTION
We have logging when a vault CR is deleted.
From user perspective, it would be nice to know when it is created too.