### PR TITLE
example: add backup/restore operator crd

### DIFF
--- a/example/etcd_backup/backup_operator_crd.yaml
+++ b/example/etcd_backup/backup_operator_crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdbackups.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  names:
+    kind: EtcdBackup
+    plural: etcdbackups
+  scope: Namespaced
+  version: v1beta2

--- a/example/etcd_restore/restore_operator_crd.yaml
+++ b/example/etcd_restore/restore_operator_crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdrestores.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  names:
+    kind: EtcdRestore
+    plural: etcdrestores
+  scope: Namespaced
+  version: v1beta2


### PR DESCRIPTION
[skip ci]

add backup/restore operator crd example. 
etcd/restore operators will not able to create crd if they don't have cluster wide access. Hence, a user with privilege can create crd for them.