### PR TITLE
*: package e2e tests inside a test pod

### DIFF
--- a/hack/ci/run_e2e
+++ b/hack/ci/run_e2e
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GOROOT="/usr/local/go"
+export PATH=$GOROOT/bin:$PATH
+
+go version
+kubectl version
+
+: ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+
+# Default values for e2e and upgrade test envs
+GIT_VERSION=$(git rev-parse HEAD)
+OPERATOR_IMAGE=${OPERATOR_IMAGE:-"quay.io/coreos/vault-operator-dev:${GIT_VERSION}"}
+E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-""}
+
+UPGRADE_TEST_SELECTOR=${UPGRADE_TEST_SELECTOR:-""}
+UPGRADE_FROM=${UPGRADE_FROM:-"quay.io/coreos/vault-operator:latest"}
+# Upgrade tests are run per PR so UPGRADE_TO is the current image built for each PR.
+UPGRADE_TO=${UPGRADE_TO:-"$OPERATOR_IMAGE"}
+
+# TODO: Containerize update vendor
+echo "updating vendor.."
+hack/update_vendor.sh 1>/dev/null
+
+# TODO: Containerize operator build
+BUILD_IMAGE=${BUILD_IMAGE:-true}
+if [[ ${BUILD_IMAGE} == "true" ]]; then
+  hack/build
+  IMAGE=${OPERATOR_IMAGE} hack/push
+fi
+
+# Containerize test-pod build
+BUILD_E2E=${BUILD_E2E:-true}
+if [[ ${BUILD_E2E} == "true" ]]; then
+  TEST_IMAGE=${TEST_IMAGE:-"quay.io/coreos/vault-operator-dev:test-pod-${GIT_VERSION}"}
+  TEST_IMAGE=${TEST_IMAGE} test/pod/docker_push
+fi
+
+echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"
+echo "OPERATOR_IMAGE: ${OPERATOR_IMAGE}"
+echo "TEST_IMAGE: ${TEST_IMAGE}"
+
+if [ -z "${PASSES-}" ]; then
+  echo "No PASSES specified. Skipping tests"
+  exit 0
+fi
+
+# Generate test-pod spec
+export TEST_POD_SPEC=${PWD}/test/pod/test-pod-spec.yaml
+export POD_NAME=${POD_NAME:-"e2e-testing"}
+
+sed -e "s|<POD_NAME>|${POD_NAME}|g" \
+    -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
+    -e "s|<PASSES>|${PASSES}|g" \
+    -e "s|<OPERATOR_IMAGE>|${OPERATOR_IMAGE}|g" \
+    -e "s|<E2E_TEST_SELECTOR>|${E2E_TEST_SELECTOR}|g" \
+    -e "s|<UPGRADE_FROM>|${UPGRADE_FROM}|g" \
+    -e "s|<UPGRADE_TO>|${UPGRADE_TO}|g" \
+    test/pod/test-pod-templ.yaml > ${TEST_POD_SPEC}
+
+# Run test-pod
+test/pod/run-test-pod

--- a/hack/ci/utils.sh
+++ b/hack/ci/utils.sh
@@ -32,3 +32,25 @@ function rbac_setup() {
     sed "s/<kube-ns>/${TEST_NAMESPACE}/g" example/rbac-template.yaml > example/rbac.yaml
     kubectl -n ${TEST_NAMESPACE} create -f example/rbac.yaml
 }
+
+# This allows the test-pod to create the vault CRD
+function rbac_clusterrolebinding_setup() {
+    cat <<EOF | kubectl create -f -
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: vault-operator-test-pod
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ${TEST_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+EOF
+}
+
+function rbac_clusterrolebinding_cleanup() {
+    kubectl -n ${TEST_NAMESPACE} delete clusterrolebinding vault-operator-test-pod
+}

--- a/hack/test2
+++ b/hack/test2
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# KUBECONFIG can be an empty string and so needs to be explicitly declared to avoid an unbound variable error
+KUBECONFIG=${KUBECONFIG:-""}
+
+if [ -z "${PASSES-}" ]; then
+	PASSES="e2e"
+fi
+
+function e2e_pass {
+	E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
+	go test "./test/e2e/" -run="$E2E_TEST_SELECTOR" -timeout=30m --race --kubeconfig=${KUBECONFIG} \
+		--namespace=${TEST_NAMESPACE} \
+		--operator-image=${OPERATOR_IMAGE}
+}
+
+function upgrade_pass {
+	go test "./test/e2e/upgradetest" -timeout=30m --race --kubeconfig=${KUBECONFIG} \
+		--namespace=${TEST_NAMESPACE} \
+		--old-vop-image=$UPGRADE_FROM \
+		--new-vop-image=$UPGRADE_TO
+}
+
+for p in $PASSES; do
+	${p}_pass
+done
+
+echo "=== success ==="
+

--- a/test/pod/Dockerfile
+++ b/test/pod/Dockerfile
@@ -1,0 +1,13 @@
+# golang:1.9-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# https://github.com/golang/go/issues/14481
+FROM golang:1.9
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+ADD ./ /go/src/github.com/coreos-inc/vault-operator
+
+WORKDIR /go/src/github.com/coreos-inc/vault-operator
+
+RUN rm -rf _output _test .git .gitignore

--- a/test/pod/docker_push
+++ b/test/pod/docker_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes the test-pod image
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which docker > /dev/null; then
+	echo "docker needs to be installed"
+	exit 1
+fi
+
+: ${TEST_IMAGE:?"Need to set TEST_IMAGE, e.g. quay.io/coreos/vault-operator-dev:test-pod"}
+
+echo "building test-pod container..."
+docker build --tag "${TEST_IMAGE}" -f test/pod/Dockerfile . 1>/dev/null
+
+# For gcr users, do "gcloud docker -a" to have access.
+echo "pushing test-pod container..."
+docker push "${TEST_IMAGE}"

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+: ${POD_NAME:?"Need to set POD_NAME"}
+: ${KUBECONFIG:?"Need to set KUBECONFIG"}
+: ${TEST_POD_SPEC:?"Need to set TEST_POD_SPEC"}
+
+# Setup RBAC rules and pull secret
+source hack/ci/utils.sh
+function cleanup {
+    rbac_clusterrolebinding_cleanup
+    pull_secret_cleanup
+    kubectl -n ${TEST_NAMESPACE} delete pod ${POD_NAME}
+}
+trap cleanup EXIT
+if rbac_clusterrolebinding_setup && pull_secret_setup; then
+    echo "RBAC and pull secret setup success! ==="
+else
+    echo "RBAC and pull secret setup fail! ==="
+    exit 1
+fi
+
+# Create test-pod
+kubectl -n ${TEST_NAMESPACE} create -f ${TEST_POD_SPEC}
+
+PHASE_RUNNING="Running"
+PHASE_SUCCEEDED="Succeeded"
+RETRY_INTERVAL=5
+
+# Wait until pod is running or timeout
+echo "Waiting for test-pod to start runnning"
+TIMEOUT=90
+ELAPSED=0
+POD_PHASE=""
+until [ "${POD_PHASE}" == "${PHASE_RUNNING}" ]
+do
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+        echo "Timeout waiting for test-pod ${POD_NAME} to become running"
+        echo "=============="
+        kubectl -n ${TEST_NAMESPACE} describe pod ${POD_NAME}
+        echo "=============="
+        exit 1
+    fi
+    sleep ${RETRY_INTERVAL}
+    ELAPSED=$(( $ELAPSED + $RETRY_INTERVAL ))
+    POD_PHASE=$(kubectl -n ${TEST_NAMESPACE} get pod ${POD_NAME} -o jsonpath='{.status.phase}')
+done
+
+# Print out and save logs to a file until the pod stops running
+echo "collecting logs =========="
+
+DOCKER_REPO_ROOT="/go/src/github.com/coreos-inc/vault-operator"
+mkdir -p _output/logs/
+cp $KUBECONFIG _output/kubeconfig
+
+docker run --rm \
+    -v "$PWD":"$DOCKER_REPO_ROOT" \
+    -w "$DOCKER_REPO_ROOT" \
+    gcr.io/coreos-k8s-scale-testing/logcollector \
+    logcollector --kubeconfig=${DOCKER_REPO_ROOT}/_output/kubeconfig --e2e-podname=${POD_NAME} \
+    --namespace=${TEST_NAMESPACE} --logs-dir="_output/logs/"
+
+# Check for pod success or failure
+POD_PHASE=$(kubectl -n ${TEST_NAMESPACE} get pod ${POD_NAME} -o jsonpath='{.status.phase}')
+if [ "${POD_PHASE}" == "${PHASE_SUCCEEDED}" ]; then
+    echo "e2e tests finished successfully"
+else
+    echo "e2e tests failed"
+    kubectl -n ${TEST_NAMESPACE} describe pod ${POD_NAME}
+    exit 1
+fi

--- a/test/pod/test-pod-templ.yaml
+++ b/test/pod/test-pod-templ.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: <POD_NAME>
+spec:
+  restartPolicy: Never
+  imagePullSecrets:
+  - name: coreos-pull-secret
+  containers:
+  - name: <POD_NAME>
+    image: <TEST_IMAGE>
+    imagePullPolicy: Always
+    command: ["hack/test2"]
+    resources:
+      requests:
+        cpu: 1
+    env:
+      - name: TEST_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: PASSES
+        value: <PASSES>
+      - name: OPERATOR_IMAGE
+        value: <OPERATOR_IMAGE>
+      - name: E2E_TEST_SELECTOR
+        value: <E2E_TEST_SELECTOR>
+      - name: UPGRADE_FROM
+        value: <UPGRADE_FROM>
+      - name: UPGRADE_TO
+        value: <UPGRADE_TO>


### PR DESCRIPTION
[skip ci]
Adding scripts to package and run the e2e/upgrade tests inside a pod.
When tested and complete these scripts would be renamed to replace the existing CI scripts.

The workflow is the same as the pod-testing in etcd-operator:
1. `hack/ci/run_e2e`: Build vault-operator and test-pod images, and call run-test-pod
2. `test/pod/run-test-pod`: Setup RBAC and pull secret, create test-pod and run log-collector
3. `hack/test2`: Called inside the test-pod to run e2e/upgrade tests