### PR TITLE
hack/ci: containerize update vendor and operator build

### DIFF
--- a/hack/ci/build
+++ b/hack/ci/build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# This script builds the vault-operator's binary
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+mkdir -p _output
+
+DOCKER_REPO_ROOT="/go/src/github.com/coreos-inc/vault-operator"
+
+docker run --rm \
+	-v "$PWD":"$DOCKER_REPO_ROOT" \
+	-w "$DOCKER_REPO_ROOT" \
+	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder \
+	/bin/bash -c "hack/build"

--- a/hack/ci/get_dep
+++ b/hack/ci/get_dep
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+DOCKER_REPO_ROOT="/go/src/github.com/coreos-inc/vault-operator"
+
+docker run --rm \
+	-v "$PWD":"$DOCKER_REPO_ROOT" \
+	-w "$DOCKER_REPO_ROOT" \
+	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder \
+	hack/update_vendor.sh

--- a/hack/ci/run_e2e
+++ b/hack/ci/run_e2e
@@ -22,18 +22,20 @@ UPGRADE_FROM=${UPGRADE_FROM:-"quay.io/coreos/vault-operator:latest"}
 # Upgrade tests are run per PR so UPGRADE_TO is the current image built for each PR.
 UPGRADE_TO=${UPGRADE_TO:-"$OPERATOR_IMAGE"}
 
-# TODO: Containerize update vendor
-echo "updating vendor.."
-hack/update_vendor.sh 1>/dev/null
+function finish {
+  sudo chown -R "$(whoami)" ./
+}
+trap finish EXIT
 
-# TODO: Containerize operator build
+echo "updating vendor.."
+hack/ci/get_dep
+
 BUILD_IMAGE=${BUILD_IMAGE:-true}
 if [[ ${BUILD_IMAGE} == "true" ]]; then
-  hack/build
+  hack/ci/build
   IMAGE=${OPERATOR_IMAGE} hack/push
 fi
 
-# Containerize test-pod build
 BUILD_E2E=${BUILD_E2E:-true}
 if [[ ${BUILD_E2E} == "true" ]]; then
   TEST_IMAGE=${TEST_IMAGE:-"quay.io/coreos/vault-operator-dev:test-pod-${GIT_VERSION}"}


### PR DESCRIPTION
[skip ci]

Using the builder image `gcr.io/coreos-k8s-scale-testing/etcd-operator-builder` to update vendor and build the operator in a container.

/cc @hongchaodeng 