### PR TITLE
*: set vault pod to be non-root

### DIFF
--- a/example/example_vault.yaml
+++ b/example/example_vault.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example"
 spec:
   nodes: 2
-  version: "0.9.0-0"
+  version: "0.9.1-0"

--- a/hack/image/vault/Dockerfile
+++ b/hack/image/vault/Dockerfile
@@ -1,3 +1,4 @@
-FROM vault:0.9.0
+FROM vault:0.9.1
 
 RUN apk --no-cache add curl
+RUN setcap cap_ipc_lock=+ep $(readlink -f $(which vault))

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -8,7 +8,7 @@ import (
 const (
 	defaultBaseImage = "quay.io/coreos/vault"
 	// version format is "<upstream-version>-<our-version>"
-	defaultVersion = "0.9.0-0"
+	defaultVersion = "0.9.1-0"
 )
 
 type ClusterPhase string

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -190,8 +190,7 @@ func (v *Vaults) prepareVaultConfig(vr *api.VaultService) error {
 		}
 		cfgData = cm.Data[filepath.Base(k8sutil.VaultConfigPath)]
 	}
-	cfgData = vaultutil.NewConfigWithTelemetry(cfgData)
-	cfgData = vaultutil.NewConfigWithListener(cfgData)
+	cfgData = vaultutil.NewConfigWithDefaultParams(cfgData)
 	cfgData = vaultutil.NewConfigWithEtcd(cfgData, k8sutil.EtcdURLForVault(vr.Name))
 
 	cm := &v1.ConfigMap{

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -227,6 +227,11 @@ func DeployVault(kubecli kubernetes.Interface, v *api.VaultService) error {
 					},
 				},
 			}},
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser:    func(i int64) *int64 { return &i }(9000),
+				RunAsNonRoot: func(b bool) *bool { return &b }(true),
+				FSGroup:      func(i int64) *int64 { return &i }(9000),
+			},
 		},
 	}
 	if v.Spec.Pod != nil {

--- a/pkg/util/vaultutil/vault_config.go
+++ b/pkg/util/vaultutil/vault_config.go
@@ -38,14 +38,22 @@ storage "etcd" {
 }
 `
 
-// NewConfigWithTelemetry appends telemetry config to given config data
-func NewConfigWithTelemetry(data string) string {
+// NewConfigWithDefaultParams appends to given config data some default params:
+// - telemetry setting
+// - tcp listener
+func NewConfigWithDefaultParams(data string) string {
 	buf := bytes.NewBufferString(data)
 	buf.WriteString(`
 		telemetry {
 			statsd_address = "localhost:9125"
 		}
 		`)
+
+	listenerSection := fmt.Sprintf(listenerFmt,
+		filepath.Join(VaultTLSAssetDir, ServerTLSCertName),
+		filepath.Join(VaultTLSAssetDir, ServerTLSKeyName))
+	buf.WriteString(listenerSection)
+
 	return buf.String()
 }
 
@@ -55,15 +63,6 @@ func NewConfigWithEtcd(data, etcdURL string) string {
 	storageSection := fmt.Sprintf(etcdStorageFmt, etcdURL, filepath.Join(VaultTLSAssetDir, "etcd-client-ca.crt"),
 		filepath.Join(VaultTLSAssetDir, "etcd-client.crt"), filepath.Join(VaultTLSAssetDir, "etcd-client.key"))
 	data = fmt.Sprintf("%s\n%s\n", data, storageSection)
-	return data
-}
-
-// NewConfigWithListener appends the Listener to Vault config data.
-func NewConfigWithListener(data string) string {
-	listenerSection := fmt.Sprintf(listenerFmt,
-		filepath.Join(VaultTLSAssetDir, ServerTLSCertName),
-		filepath.Join(VaultTLSAssetDir, ServerTLSKeyName))
-	data = fmt.Sprintf("%s\n%s\n", data, listenerSection)
 	return data
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -11,7 +11,7 @@ import (
 func TestUpgradeVault(t *testing.T) {
 	f := framework.Global
 	vaultCR := e2eutil.NewCluster("test-vault-", f.Namespace, 2)
-	vaultCR.Spec.Version = "0.8.3-0"
+	vaultCR.Spec.Version = "0.9.1-0"
 	vaultCR, err := e2eutil.CreateCluster(t, f.VaultsCRClient, vaultCR)
 	if err != nil {
 		t.Fatalf("failed to create vault cluster: %v", err)
@@ -57,7 +57,7 @@ func TestUpgradeVault(t *testing.T) {
 	}
 
 	// Upgrade vault version
-	newVersion := "0.9.0-0"
+	newVersion := "0.9.1-1"
 	vaultCR, err = e2eutil.UpdateVersion(t, f.VaultsCRClient, vaultCR, newVersion)
 	if err != nil {
 		t.Fatalf("failed to update vault version: %v", err)


### PR DESCRIPTION
- update vault version to 0.9.1
- Our custom vault image adds IPC_LOCK cap to vault binary.
  This is available in versions >= 0.9.1-0
- set vault pod to UID 9000

ref: https://jira.coreos.com/browse/VAULT-137