### PR TITLE
k8sutil: expose prometheus metrics port on vault service

### DIFF
--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -272,11 +272,18 @@ func DeployVault(kubecli kubernetes.Interface, v *api.VaultService) error {
 		},
 		Spec: v1.ServiceSpec{
 			Selector: selector,
-			Ports: []v1.ServicePort{{
-				Name:     "vault",
-				Protocol: v1.ProtocolTCP,
-				Port:     VaultClientPort,
-			}},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "vault",
+					Protocol: v1.ProtocolTCP,
+					Port:     VaultClientPort,
+				},
+				{
+					Name:     "prometheus",
+					Protocol: v1.ProtocolTCP,
+					Port:     exporterPromPort,
+				},
+			},
 		},
 	}
 	AddOwnerRefToObject(svc, AsOwner(v))


### PR DESCRIPTION
Our `statsd-exporter` container exposes the port `9102` for prometheus metrics. 
https://github.com/coreos-inc/vault-operator/blob/master/pkg/util/k8sutil/vault.go#L197-L199
But out vault service does not expose that port.

To consume the metrics endpoint in tectonic-monitoring the `ServiceMonitor` needs to select a service that exposes the metrics port.
https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md