### PR TITLE
*: update docs and helper scripts for new status fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In this example, a Vault cluster is configured with two nodes in high availabili
 4. Verify that the Vault nodes can be viewed in the "vault" resource status:
 
       ```
-      $ kubectl -n default get vault example -o jsonpath='{.status.nodes.sealed}'
+      $ kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.sealed}'
       [example-1003480066-b757c example-1003480066-jzmwd]
       ```
 
@@ -149,10 +149,10 @@ By default the vault-operator will configure each vault pod to publish [statsd](
 
 The vault-operator runs a [statsd-exporter](https://github.com/prometheus/statsd_exporter) container inside each vault pod to convert and expose those metrics in the format for Prometheus.
 
-`curl` the `/metrics` endpoint for any available vault pod to get the Prometheus metrics:
+`curl` the `/metrics` endpoint for any vault pod to get the Prometheus metrics:
 
 ```sh
-$ VPOD=$(kubectl -n default get vault example -o jsonpath='{.status.nodes.available[0]}')
+$ VPOD=$(kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}')
 $ kubectl -n default exec -ti ${VPOD} --container=vault -- curl localhost:9102/metrics
 # HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary

--- a/doc/user/kubernetes-auth-backend.md
+++ b/doc/user/kubernetes-auth-backend.md
@@ -20,7 +20,7 @@ To enable and configure the auth backend with the necessary roles and policies, 
 1. Configure port forwarding between the local machine and the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
     ```
 
 2. Open a new terminal. Use this terminal for the rest of this guide.

--- a/doc/user/recovery.md
+++ b/doc/user/recovery.md
@@ -92,7 +92,7 @@ example-etcd-rqk62l46kw   1/1       Running   0          2m
 Configure port forwarding between the local machine and the active Vault node:
 
 ```sh
-kubectl get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl port-forward {} 8200
+kubectl get vault example -o jsonpath='{.status.vaultStatus.active}' | xargs -0 -I {} kubectl port-forward {} 8200
 ```
 
 In a separate terminal, verify that vault can retrieve the secret `secret/foo value=bar`:

--- a/doc/user/vault.md
+++ b/doc/user/vault.md
@@ -11,10 +11,10 @@ This document describes how to initialize, unseal, and access the Vault service.
 
 Initialize a new Vault cluster before performing any operations.
 
-1. Configure port forwarding between the local machine and the first available Vault node:
+1. Configure port forwarding between the local machine and the first sealed Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.available[0]}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.sealed[0]}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
     ```
 
 2. Open a new terminal.
@@ -50,7 +50,7 @@ A response confirms that the Vault CLI is ready to interact with the Vault serve
 1. Configure port forwarding between the local machine and the first sealed Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.sealed[0]}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.sealed[0]}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
     ```
 
 2. Open a new terminal.
@@ -73,13 +73,13 @@ The first node that is unsealed in a multi-node Vault cluster will become the ac
 1. Check the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}'
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}'
     ```
 
 2. Configure port forwarding between the local machine and the active Vault node:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
     ```
 
 3. Open a new terminal.
@@ -117,7 +117,7 @@ The first node that is unsealed in a multi-node Vault cluster will become the ac
 1. Set up port-forward connection to active node and Vault CLI env same as previous section:
 
     ```sh
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}' | xargs -0 -I {} kubectl -n default port-forward {} 8200
     ```
 
     Open another terminal and type:
@@ -157,7 +157,7 @@ A standby Vault node is initialized and unsealed, but does not hold the leader e
 2. Verify that the node becomes standby:
 
     ```sh
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.standby}'
+    $ kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.standby}'
     [example-1003480066-jzmwd]
     ```
 
@@ -172,7 +172,7 @@ To see how it works, terminate the active node, and wait for the standby node to
 1. Terminate the active Vault node:
 
     ```
-    kubectl -n default get vault example -o jsonpath='{.status.nodes.active}' | xargs -0 -I {} kubectl -n default delete po {}
+    kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}' | xargs -0 -I {} kubectl -n default delete po {}
     ```
 
     The standby node becomes active.
@@ -180,7 +180,7 @@ To see how it works, terminate the active node, and wait for the standby node to
 2. Verify that the previous standby node is now active:
 
     ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.active}'
+    $ kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.active}'
     example-1003480066-jzmwd
     ```
 
@@ -196,17 +196,10 @@ To see how it works, perform the following:
 
    If a node has not yet been terminated, follow the instructions in the [Automated failover](#automated-failover) section above.
 
-2. Verify that a new Vault node is created:
+2. Verify that the newly sealed Vault node is created:
 
     ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.available}'
-    [example-1003480066-jzmwd example-994933690-h066h]
-    ```
-
-3. Verify that the newly created Vault node is sealed:
-
-    ```
-    $ kubectl -n default get vault example -o jsonpath='{.status.nodes.sealed}'
+    $ kubectl -n default get vault example -o jsonpath='{.status.vaultStatus.sealed}'
     [example-994933690-h066h]
     ```
 

--- a/hack/helper/create-cluster.sh
+++ b/hack/helper/create-cluster.sh
@@ -34,7 +34,7 @@ while [ "${NUM_SEALED}" -ne "${NUM_NODES}" ]
 do
     sleep ${RETRY_INTERVAL}
 
-    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
+    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.sealed}' | sed 's/^.\(.*\).$/\1/' )
     IFS=' ' read -r -a SEALED_ARRAY <<< "${SEALED_NODES}"
     NUM_SEALED=${#SEALED_ARRAY[@]}
 done
@@ -62,7 +62,7 @@ while [ -z "${ACT_NODE}" ]
 do
     echo "Waiting for active node to show up"
     sleep ${RETRY_INTERVAL}
-    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
+    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.active}')
 done
 
 echo "Vault cluster setup complete!"

--- a/hack/helper/unseal.sh
+++ b/hack/helper/unseal.sh
@@ -12,7 +12,7 @@ set -o pipefail
 : ${UNSEAL_KEY:?"Need to set UNSEAL_KEY"}
 
 # Get all sealed nodes
-SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
+SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.sealed}' | sed 's/^.\(.*\).$/\1/' )
 if [ "${SEALED_NODES}" == "nil" ]; then
     echo "No sealed nodes found"
     exit 0

--- a/hack/helper/upgrade.sh
+++ b/hack/helper/upgrade.sh
@@ -26,7 +26,7 @@ NUM_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{
 # Check the cluster conditions before upgrade can be performed: 1 active and 0 sealed nodes
 # Check for 1 active node
 # There must be an active node before upgrade in order for N sealed nodes to show up after upgrade. Otherwise if N=1 and it is sealed then after upgrade there will be 2 sealed nodes.
-ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
+ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.active}')
 if [ -z "$ACT_NODE" ]; then
     echo "Vault cluster must have an active node before upgrading"
     exit 1
@@ -45,7 +45,7 @@ while [ "${NUM_SEALED}" -ne "${NUM_NODES}" ]
 do
     sleep ${RETRY_INTERVAL}
 
-    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.sealed}' | sed 's/^.\(.*\).$/\1/' )
+    SEALED_NODES=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.sealed}' | sed 's/^.\(.*\).$/\1/' )
     IFS=' ' read -r -a SEALED_ARRAY <<< "${SEALED_NODES}"
     NUM_SEALED=${#SEALED_ARRAY[@]}
 done
@@ -62,7 +62,7 @@ do
     sleep ${RETRY_INTERVAL}
 
     # Get the active node name
-    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.nodes.active}')
+    ACT_NODE=$(kubectl -n ${KUBE_NS} get vault ${VAULT_CLUSTER_NAME} -o jsonpath='{.status.vaultStatus.active}')
     if [ -z "$ACT_NODE" ]; then
         echo "No active node found in CR status. Retrying"
         continue

--- a/test/e2e/e2eutil/vault_util.go
+++ b/test/e2e/e2eutil/vault_util.go
@@ -42,7 +42,7 @@ func InitializeVault(t *testing.T, vaultsCRClient versioned.Interface, vault *ap
 	if err != nil {
 		t.Fatalf("failed to initialize vault: %v", err)
 	}
-	// Wait until initialized nodes to be reflected on status.nodes.Sealed
+	// Wait until initialized nodes to be reflected on status.vaultStatus.Sealed
 	vault, err = WaitSealedVaultsUp(t, vaultsCRClient, int(vault.Spec.Nodes), 6, vault)
 	if err != nil {
 		t.Fatalf("failed to wait for vault nodes to become sealed: %v", err)


### PR DESCRIPTION
[skip ci]
Followup to #269 to update the docs and helper scripts according to the new CR status.

There are some changes needed in the e2e tests code. Like skip waiting for available and just wait for sealed nodes but that doesn't change the test functionality and will be done in a separate PR.