### PR TITLE
pkg/apis: remove omitempty for VaultStatus fields

### DIFF
--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -110,7 +110,7 @@ type VaultServiceStatus struct {
 	ClientPort int `json:"clientPort,omitempty"`
 
 	// VaultStatus is the set of Vault node specific statuses: Active, Standby, and Sealed
-	VaultStatus VaultStatus `json:"vaultStatus,omitempty"`
+	VaultStatus VaultStatus `json:"vaultStatus"`
 
 	// PodNames of updated Vault nodes. Updated means the Vault container image version
 	// matches the spec's version.
@@ -121,15 +121,15 @@ type VaultStatus struct {
 	// PodName of the active Vault node. Active node is unsealed.
 	// Only active node can serve requests.
 	// Vault service only points to the active node.
-	Active string `json:"active,omitempty"`
+	Active string `json:"active"`
 
 	// PodNames of the standby Vault nodes. Standby nodes are unsealed.
 	// Standby nodes do not process requests, and instead redirect to the active Vault.
-	Standby []string `json:"standby,omitempty"`
+	Standby []string `json:"standby"`
 
 	// PodNames of Sealed Vault nodes. Sealed nodes MUST be manually unsealed to
 	// become standby or leader.
-	Sealed []string `json:"sealed,omitempty"`
+	Sealed []string `json:"sealed"`
 }
 
 // DefaultVaultClientTLSSecretName returns the name of the default vault client TLS secret


### PR DESCRIPTION
@hongchaodeng We discussed displaying the `VaultStatus` fields even if they're empty to make it more clear what the 3 states are. But looking at an example spec I see the empty array field shows up as `null` which is not ideal.
```
vaultStatus:
      active: example-676ff58b6f-vz74n
      sealed: null
      standby:
      - example-676ff58b6f-wdw66
```