### PR TITLE
k8sutil: remove default non-root security context

### DIFF
--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -253,11 +253,6 @@ func DeployVault(kubecli kubernetes.Interface, v *api.VaultService) error {
 					},
 				},
 			}},
-			SecurityContext: &v1.PodSecurityContext{
-				RunAsUser:    func(i int64) *int64 { return &i }(9000),
-				RunAsNonRoot: func(b bool) *bool { return &b }(true),
-				FSGroup:      func(i int64) *int64 { return &i }(9000),
-			},
 		},
 	}
 	if v.Spec.Pod != nil {


### PR DESCRIPTION
Reverting back to the default pod security context.

The non-root security context should not be hardcoded as that can conflict with Admission Control Policies on a cluster that enforces what the allowed security context values should be.

This should be made configurable through the PodPolicy
https://github.com/coreos-inc/vault-operator/blob/master/pkg/apis/vault/v1alpha1/types.go#L79

/cc @fanminshi 