### PR TITLE
k8sutil: remove 30s default request timeout for kube client

### DIFF
--- a/pkg/util/k8sutil/client_util.go
+++ b/pkg/util/k8sutil/client_util.go
@@ -17,14 +17,11 @@ package k8sutil
 import (
 	"net"
 	"os"
-	"time"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
-
-const defaultKubeAPIRequestTimeout = 30 * time.Second
 
 func MustNewKubeExtClient() apiextensionsclient.Interface {
 	cfg, err := InClusterConfig()
@@ -56,12 +53,5 @@ func InClusterConfig() (*rest.Config, error) {
 		os.Setenv("KUBERNETES_SERVICE_PORT", "443")
 	}
 
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// Set a reasonable default request timeout
-	cfg.Timeout = defaultKubeAPIRequestTimeout
-	return cfg, nil
+	return rest.InClusterConfig()
 }


### PR DESCRIPTION
Revert #279 
Setting a 30s timeout causes the watch stream in the informer to break and reset every 30s. This ends up polluting the vault-operator logs
```
time="2018-04-13T18:09:05Z" level=info msg="starting Vaults controller"
ERROR: logging before flag.Parse: E0413 18:09:35.775214       1 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
ERROR: logging before flag.Parse: E0413 18:10:05.775978       1 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
ERROR: logging before flag.Parse: E0413 18:10:35.777186       1 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
ERROR: logging before flag.Parse: E0413 18:11:05.778623       1 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
```

We should wait until upstream allows passing ctx into clients rather than set a global timeout.
kubernetes/kubernetes#46503

/cc @fanminshi 
