### PR TITLE
README: Highlight vault usage and recovery guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,13 @@ In this example, a Vault cluster is configured with two nodes in high availabili
 
       Vault is unready because it is uninitialized and sealed.
 
-For information on using the deployed Vault, see [vault.md](./doc/user/vault.md) .
+### Using the Vault cluster
+
+For information on using the deployed Vault cluster, see the [Vault usage guide](./doc/user/vault.md).
 
 Consult the [monitoring guide](./doc/user/monitoring.md) on how to monitor and alert on a Vault cluster with Prometheus.
+
+See the [recovery guide](./doc/user/recovery.md) on how to backup and restore Vault cluster data using the etcd opeartor
 
 ### Uninstalling Vault operator
 

--- a/doc/user/vault.md
+++ b/doc/user/vault.md
@@ -1,6 +1,6 @@
-# Initialize and Unseal a Vault Cluster
+# Vault Usage Guide
 
-This document describes how to initialize, unseal, and access the Vault service.
+This document describes how to initialize, unseal, and interact with a deployed Vault cluster.
 
 ## Prerequisites
 


### PR DESCRIPTION
[skip ci]
The vault usage and recovery guides need to be highlighted in their own section on the README.

/cc @fanminshi 