### PR TITLE
test: run e2e test pod without framework setup

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -97,6 +97,11 @@ func Setup() error {
 
 // Teardown removes the vault-operator deployment and waits for its termination
 func Teardown() error {
+	// Skip the operators teardown if either image is not specified
+	if len(Global.vopImage) == 0 || len(Global.eopImage) == 0 {
+		return nil
+	}
+
 	err := Global.KubeClient.CoreV1().Pods(Global.Namespace).Delete(vaultOperatorName, k8sutil.CascadeDeleteBackground())
 	if err != nil {
 		return fmt.Errorf("failed to delete pod: %v", err)
@@ -111,6 +116,11 @@ func Teardown() error {
 }
 
 func (f *Framework) setup() error {
+	// Skip the operators setup if either image is not specified
+	if len(Global.vopImage) == 0 || len(Global.eopImage) == 0 {
+		return nil
+	}
+
 	if err := f.deployEtcdOperatorPod(); err != nil {
 		return fmt.Errorf("failed to setup etcd operator: %v", err)
 	}

--- a/test/pod/simple/Dockerfile
+++ b/test/pod/simple/Dockerfile
@@ -1,0 +1,16 @@
+# golang:X-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# https://github.com/golang/go/issues/14481
+FROM golang:1.10.2 as builder
+
+ADD ./ /go/src/github.com/coreos/vault-operator
+
+WORKDIR /go/src/github.com/coreos/vault-operator
+
+RUN go test ./test/e2e/ -c -o /bin/vault-operator-e2e --race
+
+FROM busybox:1.28.3-glibc
+
+COPY --from=builder /bin/vault-operator-e2e /bin
+COPY --from=builder /go/src/github.com/coreos/vault-operator/test/pod/simple/run-e2e /bin/run-e2e
+
+CMD ["/bin/run-e2e"]

--- a/test/pod/simple/run-e2e
+++ b/test/pod/simple/run-e2e
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+: ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+
+# Run e2e tests
+/bin/vault-operator-e2e -test.timeout 30m -test.failfast -test.parallel 4 --namespace=${TEST_NAMESPACE}

--- a/test/pod/simple/simple-pod-templ.yaml
+++ b/test/pod/simple/simple-pod-templ.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vault-operator-e2e-tests
+spec:
+  restartPolicy: Never
+  containers:
+  - name: vault-operator-e2e-tests
+    image: <TEST_IMAGE>
+    imagePullPolicy: Always
+    env:
+      - name: TEST_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace


### PR DESCRIPTION
Added a simplified version of the current [test/pod](https://github.com/coreos/vault-operator/tree/master/test/pod) that allows the e2e tests to be run against an existing vault and etcd operator setup.

The multistage Dockerfile builds the test binary separately to reduce the final test-container image size.

Additionally the backup and restore tests are skipped if the S3 bucket and AWS secret env are not set.

/cc @fanminshi @colhom 