### PR TITLE
Custom Service Account for vault pods

### DIFF
--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -74,7 +74,8 @@ type VaultServiceSpec struct {
 	// TLS policy of vault nodes
 	TLS *TLSPolicy `json:"TLS,omitempty"`
 
-	// service account
+	// Service Account
+	// Default: default
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
@@ -105,6 +106,10 @@ func (v *VaultService) SetDefaults() bool {
 			ServerSecret: DefaultVaultServerTLSSecretName(v.Name),
 			ClientSecret: DefaultVaultClientTLSSecretName(v.Name),
 		}}
+		changed = true
+	}
+	if len(vs.ServiceAccountName) == 0{
+		vs.ServiceAccountName = "default"
 		changed = true
 	}
 	return changed

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -73,6 +73,9 @@ type VaultServiceSpec struct {
 
 	// TLS policy of vault nodes
 	TLS *TLSPolicy `json:"TLS,omitempty"`
+
+	// service account
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // PodPolicy defines the policy for pods owned by vault operator.

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -242,6 +242,7 @@ func DeployVault(kubecli kubernetes.Interface, v *api.VaultService) error {
 			Labels: selector,
 		},
 		Spec: v1.PodSpec{
+			ServiceAccountName: v.Spec.ServiceAccountName,
 			Containers: []v1.Container{vaultContainer(v), statsdExporterContainer()},
 			Volumes: []v1.Volume{{
 				Name: vaultConfigVolName,


### PR DESCRIPTION
* Fixes Issue: #313 

* Added Service Account Name to `pkg/apis/vault/v1alpha1/types.go` VaultServiceSpec to resolve `serviceAccountName:{val}`.

* Added `ServiceAccountName` field to `pkg/util/k8sutil/vault.go` to allow the vault pods to use a custom, user specified, service account other than default.