### PR TITLE
Modify audit-enable as it is deprecated

### DIFF
--- a/doc/user/vault.md
+++ b/doc/user/vault.md
@@ -131,7 +131,7 @@ The first node that is unsealed in a multi-node Vault cluster will become the ac
 2. Enable file audit backend and write audit log to standard output:
 
     ```sh
-    vault audit-enable file file_path=stdout
+    vault audit enable file file_path=stdout
     ```
 
    Then use docker/Kubernetes log collector to save logs and view later.


### PR DESCRIPTION
vault recommends to use 'vault audit enable' as audit-enable command is deprecated and will be removed in 0.11.

https://github.com/hashicorp/vault/blob/master/command/commands.go#L578