### PR TITLE
made vault-operator track vault upstream image, upgrade and enable ui

### DIFF
--- a/example/example_vault.yaml
+++ b/example/example_vault.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example"
 spec:
   nodes: 2
-  version: "0.9.1-0"
+  version: "0.10.2"

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	defaultBaseImage = "quay.io/coreos/vault"
+	defaultBaseImage = "vault"
 	// version format is "<upstream-version>-<our-version>"
-	defaultVersion = "0.9.1-0"
+	defaultVersion = "0.10.2"
 )
 
 type ClusterPhase string

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -146,9 +146,9 @@ func vaultContainer(v *api.VaultService) v1.Container {
 		Name:  "vault",
 		Image: fmt.Sprintf("%s:%s", v.Spec.BaseImage, v.Spec.Version),
 		Command: []string{
-			"/bin/vault",
-			"server",
-			"-config=" + VaultConfigPath,
+			"sh",
+			"-c",
+			"setcap cap_ipc_lock=+ep /bin/vault && apk --no-cache add curl && exec /bin/vault server -config=" + VaultConfigPath,
 		},
 		Env: []v1.EnvVar{
 			{

--- a/pkg/util/vaultutil/vault_config.go
+++ b/pkg/util/vaultutil/vault_config.go
@@ -58,6 +58,8 @@ storage "etcd" {
 func NewConfigWithDefaultParams(data string) string {
 	buf := bytes.NewBufferString(data)
 	buf.WriteString(`
+ui = true
+
 telemetry {
 	statsd_address = "localhost:9125"
 }


### PR DESCRIPTION
By installing curl into the vault image at initialization, we don't need to have a customized vault image, and can track upstream.

This also upgrades to vault 0.10.2 and enables the (new) ui

closes #290


### considerations:

This does mean that vault will install cURL from the configured apk repositories at initialization time, which makes it less suitable for an air-gapped cluster. On the flipside, those clusters can probably not use the operator anyway.

If you look closely I've reversed the (logical) order at sh -c to first drop the capabilities, then install curl, en then launch. This is because otherwise, the OS would somehow still be modifying the /bin/vault while it was being launched, causing a "text file busy" (modifying running executable) error. 

credits to @kesselborn for suggesting this approach.