### PR TITLE
Update vault-tokenreview-binding.yaml

### DIFF
--- a/example/k8s_auth/vault-tokenreview-binding.yaml
+++ b/example/k8s_auth/vault-tokenreview-binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vault-tokenreview
-  namespace: vault-services
+  namespace: default


### PR DESCRIPTION
Updating namespace to match kube auth backend doc, otherwise the tutorial doesn't work