### PR TITLE
Add PersistentVolumeClaimSpec to Vault Types

### DIFF
--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -73,6 +73,9 @@ type VaultServiceSpec struct {
 
 	// TLS policy of vault nodes
 	TLS *TLSPolicy `json:"TLS,omitempty"`
+
+	// ETCD PVC
+	ETCDPVC string `json:"etcdPVC,omitempty"`
 }
 
 // PodPolicy defines the policy for pods owned by vault operator.

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -75,7 +75,7 @@ type VaultServiceSpec struct {
 	TLS *TLSPolicy `json:"TLS,omitempty"`
 
 	// PersistentVolumeClaimSpec for the ETCD Cluster
-	PersistentVolumeClaimSpec *v1.PersistentVolumeClaimSpec `json:"PersistentVolumeClaimSpec,omitempty"`
+	PersistentVolumeClaimSpec *v1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
 }
 
 // PodPolicy defines the policy for pods owned by vault operator.

--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -74,8 +74,8 @@ type VaultServiceSpec struct {
 	// TLS policy of vault nodes
 	TLS *TLSPolicy `json:"TLS,omitempty"`
 
-	// ETCD PVC
-	ETCDPVC string `json:"etcdPVC,omitempty"`
+	// PersistentVolumeClaimSpec for the ETCD Cluster
+	PersistentVolumeClaimSpec *v1.PersistentVolumeClaimSpec `json:"PersistentVolumeClaimSpec,omitempty"`
 }
 
 // PodPolicy defines the policy for pods owned by vault operator.

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -118,7 +118,7 @@ func DeployEtcdCluster(etcdCRCli etcdCRClient.Interface, v *api.VaultService) er
 				},
 			},
 		}
-	} else { // Otherwise, if pvc size is not > 0, don't PVC back the ETCD Cluster
+	} else { // Otherwise, deploy default etcd cluster with no PVCs (ephemeral)
 		etcdCluster = &etcdCRAPI.EtcdCluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       etcdCRAPI.EtcdClusterResourceKind,


### PR DESCRIPTION
I've added a `PersistentVolumeClaimSpec` to Vault Types which gets called in the `DeployEtcdCluster` function.

I've added an if statement to the `DeployEtcdCluster` function to check if a `PersistentVolumeClaimSpec` has been set.

This fixes (at least partially) Issue #319 

Let me know what you think.