### PR TITLE
example: change namespace in ClusterRoleBinding

### DIFF
--- a/example/k8s_auth/vault-tokenreview-binding.yaml
+++ b/example/k8s_auth/vault-tokenreview-binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vault-tokenreview
-  namespace: vault-services
+  namespace: default


### PR DESCRIPTION
Hello! 
I think the namespace in `example/k8s_auth/vault-tokenreview-binding.yaml` should be `default` because in the doc [kubernetes-auth-backend](https://github.com/azalio/vault-operator/blob/master/doc/user/kubernetes-auth-backend.md) I see that we create a service account in the default namespace.
```
kubectl -n default create serviceaccount vault-tokenreview
```