### PR TITLE
add custom etcd image to vault-service CRD

### DIFF
--- a/pkg/apis/vault/v1alpha1/types.go
+++ b/pkg/apis/vault/v1alpha1/types.go
@@ -57,6 +57,9 @@ type VaultServiceSpec struct {
 
 	// Base image to use for a Vault deployment.
 	BaseImage string `json:"baseImage"`
+	
+	// custom etcd image to use instead of 'quay.io/coreos/etcd'
+	EtcdRepository string `json: "etcdRepository"`
 
 	// Version of Vault to be deployed.
 	Version string `json:"version"`

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -104,6 +104,12 @@ func DeployEtcdCluster(etcdCRCli etcdCRClient.Interface, v *api.VaultService) er
 			},
 		},
 	}
+	
+	// Allow custom etcd image to be used in cases where default quay.io/coreos/etcd is not usable.
+	if v.Spec.EtcdRepository != nil {
+		etcdCluster.Spec.Repository = v.Spec.EtcdRepository	
+	}
+	
 	if v.Spec.Pod != nil {
 		etcdCluster.Spec.Pod.Resources = v.Spec.Pod.Resources
 	}


### PR DESCRIPTION
The etcd-operator allows the customization of the etcd image in the etcd CRD named 'repository', this PR extends that option to the vault-operator as well using the VaultServiceSpec named 'EtcdRepository'.

I am not able to test this, so please verify that
`
if v.Spec.EtcdRepository != nil {
	etcdCluster.Spec.Repository = v.Spec.EtcdRepository	
}
`
will correctly set the Repository and it doesnt need a pointer or != "".
