### PR TITLE
[fix] #366 fix etcd pod failed to exit init container

### DIFF
--- a/example/etcd-operator-deploy.yaml
+++ b/example/etcd-operator-deploy.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.8.3
+        image: quay.io/coreos/etcd-operator:v0.8.4
         command:
         - etcd-operator
         - "--create-crd=false"
@@ -27,7 +27,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: etcd-backup-operator
-        image: quay.io/coreos/etcd-operator:v0.8.3
+        image: quay.io/coreos/etcd-operator:v0.8.4
         command:
         - etcd-backup-operator
         - "--create-crd=false"
@@ -41,7 +41,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: etcd-restore-operator
-        image: quay.io/coreos/etcd-operator:v0.8.3
+        image: quay.io/coreos/etcd-operator:v0.8.4
         command:
         - etcd-restore-operator
         - "--create-crd=false"
@@ -54,4 +54,3 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-


### PR DESCRIPTION
fix : https://github.com/coreos/vault-operator/issues/366

I tried `Getting start` on README.md and apply configs on `example/` dir.
but, vault didn't start.
Because etcd-operator fail to exit init container and don't start.

This problem is bug of etcd-operator version 0.8.3.
It fixed to version 0.8.4.
https://github.com/coreos/etcd-operator/blob/master/CHANGELOG.md

Please update etcd-operator from `example/` dir.