### PR TITLE
set namespace to default in vault-tokenreview-binding.yaml 

### DIFF
--- a/example/k8s_auth/vault-tokenreview-binding.yaml
+++ b/example/k8s_auth/vault-tokenreview-binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vault-tokenreview
-  namespace: vault-services
+  namespace: default


### PR DESCRIPTION
As described in https://github.com/coreos/vault-operator/issues/320 setting the namespace to "default" fixes the broken login behaviour. 