### PR TITLE
Keep all resources in vault namespace and support kubernetes 16+

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-operator
+  namespace: vault
 spec:
   selector:
     matchLabels:

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -1,14 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-operator
 spec:
+  selector:
+    matchLabels:
+      name: vault-operator
   replicas: 1
   template:
     metadata:
       labels:
         name: vault-operator
     spec:
+      serviceAccountName: vault
       containers:
       - name: vault-operator
         image: quay.io/coreos/vault-operator:latest

--- a/example/etcd-operator-deploy.yaml
+++ b/example/etcd-operator-deploy.yaml
@@ -1,16 +1,21 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd-operator
+  namespace: vault
   labels:
     name: etcd-operator
 spec:
+  selector:
+    matchLabels:
+      name: etcd-operator
   replicas: 1
   template:
     metadata:
       labels:
         name: etcd-operator
     spec:
+      serviceAccountName: vault
       containers:
       - name: etcd-operator
         image: quay.io/coreos/etcd-operator:v0.8.3

--- a/example/rbac-template.yaml
+++ b/example/rbac-template.yaml
@@ -1,7 +1,14 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vault
+  namespace: vault
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: vault-operator-role
+  namespace: vault
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -24,7 +31,7 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - "" # "" indicates the core API group
+  - ""
   resources:
   - pods
   - services
@@ -43,15 +50,15 @@ rules:
   - "*"
 
 ---
-
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: vault-operator-rolebinding
+  namespace: vault
 subjects:
 - kind: ServiceAccount
-  name: <service-account>
-  namespace: <namespace>
+  name: vault
+  namespace: vault
 roleRef:
   kind: Role
   name: vault-operator-role


### PR DESCRIPTION
Create deplyments , role and rolebinding in vault namespace by default 
Include vault serviceaccount and bindings in that namespace to avoid using the default serviceaccount and default namespace 
Add support for kubernetes 16+ api 